### PR TITLE
Disable polling the messages.

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/pollWorker.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/pollWorker.js
@@ -86,4 +86,5 @@ addEventListener("message", function(message) {
 });
 
 startPollingData();
-startPollingMessages();
+// Disable until its fixed
+//startPollingMessages();


### PR DESCRIPTION
With this on ZAP and the HUD can quickly become unusable.
This is partly because the full messages are returned, including the
requests and responses, while it actually only needs the sort of data
shown in the ZAP History tab
In any case it looks like its broken - it keeps returning the first 20
messages.
I think it should
* Not poll by default, ie only when the Timeline/History panel is shown
* Use a new API endpoint that just returns the data needed