### PR TITLE
handle empty alerts when the alert fetching request fails

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/pageAlerts.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/pageAlerts.js
@@ -34,6 +34,10 @@ var PageAlerts = (function() {
 		var risks = ["Low", "Medium", "High", "Informational"];
 		var alertTypes = [];
 
+		if (!(alerts && alerts.length)) {
+			return formatted;
+		}
+
 		for (var i=0; i<risks.length; i++) {
 			var risk = risks[i];
 			var riskAlerts = alerts.filter(function(alert) {return alert.risk === risk; });


### PR DESCRIPTION
Fixes an error I was seeing like "no method filter on undefined."