### PR TITLE
Add injectionHtmlTimeline to add-on manifest

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/hud/ZapAddOn.xml
@@ -20,6 +20,7 @@
 		<file>hud/libraries/jquery-ui.theme.css</file>
 		<file>hud/libraries/localforage.min.js</file>
 		<file>hud/injectionHtml.html</file>
+		<file>hud/injectionHtmlTimeline.html</file>
 		<file>hud/inject.js</file>
 		<file>hud/panel.html</file>
 		<file>hud/panel.css</file>


### PR DESCRIPTION
Change ZapAddOn.xml file to include injectionHtmlTimeline.html in the
bundled files (the file is required when the timeline is enabled).