### PR TITLE
Address compilation warnings

### DIFF
--- a/src/org/zaproxy/zap/extension/ApiGenerator.java
+++ b/src/org/zaproxy/zap/extension/ApiGenerator.java
@@ -59,16 +59,16 @@ public class ApiGenerator {
 	public static void main(String[] args) {
 		try {
 			JavaAPIGenerator japi = new JavaAPIGenerator(JAVA_OUTPUT_DIR, true);
-			japi.generateJavaFiles(getApiImplementors());
+			japi.generateAPIFiles(getApiImplementors());
 
 			NodeJSAPIGenerator napi = new NodeJSAPIGenerator("../zaproxy/nodejs/api/zapv2", true);
-			napi.generateNodeJSFiles(getApiImplementors());
+			napi.generateAPIFiles(getApiImplementors());
 		
 			PhpAPIGenerator phapi = new PhpAPIGenerator("../zaproxy/php/api/zapv2/src/Zap", true);
-			phapi.generatePhpFiles(getApiImplementors());
+			phapi.generateAPIFiles(getApiImplementors());
 
 			PythonAPIGenerator pyapi = new PythonAPIGenerator(PYTHON_OUTPUT_DIR, true);
-			pyapi.generatePythonFiles(getApiImplementors());
+			pyapi.generateAPIFiles(getApiImplementors());
 
 			//WikiAPIGenerator wapi = new WikiAPIGenerator("../zaproxy-wiki", true);
 			//wapi.generateWikiFiles(getApiImplementors());


### PR DESCRIPTION
Remove redundant casts, deprecations, usage of raw types, and unchecked
calls. Also, remove an unused import.