### PR TITLE
Update to Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: java
 script: ant -buildfile build/build.xml test
 sudo: false
+
+jdk:
+  - oraclejdk8
+  - openjdk8

--- a/build/build.xml
+++ b/build/build.xml
@@ -2,7 +2,7 @@
 	<description>Build ZAP extensions</description>
 
 	<property name="src" location="../src" />
-	<property name="src.version" value="1.7" />
+	<property name="src.version" value="1.8" />
 	<property name="test.src" location="../test" />
 	<property name="test.lib" location="../testlib" />
 	<property name="test.build" location="buildtest" />

--- a/src/org/zaproxy/zap/extension/hud/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/hud/ZapAddOn.xml
@@ -48,6 +48,6 @@
 		<file>hud/tools/break.js</file>
 		<file>hud/tools/attack.js</file>
 	</files>
-	<not-before-version>2.6.0</not-before-version>
+	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>


### PR DESCRIPTION
Change build.xml to compile with Java 8.
Change Travis CI configuration file to use Java 8 (even though it's not
yet enabled).
Change ZapAddOn.xml file to update minimum ZAP version to 2.7.0, latest
and the one targeting Java 8.