### PR TITLE
Ignore non-HUD scripts when handling added scripts

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -402,6 +402,10 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
 
     @Override
     public void scriptAdded(ScriptWrapper sw, boolean arg1) {
+        if (!hudScriptType.equals(sw.getType())) {
+            return;
+        }
+
         // Detect duplicated files and save them to the right place
         if (sw.getFile() == null) {
             try {


### PR DESCRIPTION
Change ExtensionHUD to ignore the added script if not of HUD type,
otherwise it would "hijack" other scripts types.