### PR TITLE
Improve alert list dialog links

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -230,6 +230,7 @@ public class HudAPI extends ApiImplementor {
 					alertAtts.put("risk", Alert.MSG_RISK[alert.getRisk()]);
 					alertAtts.put("param", alert.getParam());
 					alertAtts.put("id", Integer.toString(alert.getAlertId()));
+					alertAtts.put("uri", alert.getUri());
 					summary.add(alertAtts);
 				}
 				for (Entry<Integer, Map<String, Integer>> entry : alertCounts.entrySet()) {
@@ -269,6 +270,7 @@ public class HudAPI extends ApiImplementor {
 								alertAtts.put("param", alert.getParam());
 								alertAtts.put("id", Integer.toString(alert.getAlertId()));
 								//pageAlerts.addItem(new ApiResponseSet("alert", alertAtts));
+								alertAtts.put("uri", alert.getUri());
 								pageAlerts.add(alertAtts);
 							}
 						}

--- a/src/org/zaproxy/zap/extension/hud/files/hud/display.html
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/display.html
@@ -121,12 +121,12 @@
             <div class="accordion">
                 <input type="checkbox" :id="title" name="accordion-checkbox" hidden>
                 <label class="accordion-header" :for="title">
-                    {{ title }}
+                    {{ title }} ({{ alerts.length }})
                 </label>
                 <div class="accordion-body">
                     <ul class="menu menu-nav">
                         <li class="menu-item" v-for="alert in alerts"> 
-                            <a @click="alertSelect(alert)"> {{ title }} ({{ alert.id }}) </a>
+                            <a @click="alertSelect(alert)"> {{ alert.uri }} </a>
                         </li>
                     </ul>
                 </div>

--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/alertUtils.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/alertUtils.js
@@ -44,7 +44,7 @@ var alertUtils = (function() {
 					then(function(json) {
 
 						var config = {};
-						config.title = json.alert.alert + ' (' + json.alert.id + ')';
+						config.title = json.alert.alert;
 						config.details = json.alert;
 
 						messageFrame("display", {action: "showAlertDetails", config: config});


### PR DESCRIPTION
Currently the alert list dialogs show:

- Alert name
  - Alert name (index)
  - Alert name (index)
  - Alert name (index)

This isnt that useful :)
Changed to be similar to the desktop UI:

- Alert name (count)
  - URL 1
  - URL 2
  - URL 3

