### PR TITLE
Add options for enabled, inScopeOnly, devMode and allowUnsafeEval

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -43,6 +43,9 @@ import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.ZAP;
+import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptEventListener;
 import org.zaproxy.zap.extension.script.ScriptType;
@@ -132,6 +135,7 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
 	public void hook(ExtensionHook extensionHook) {
 		super.hook(extensionHook);
 	    
+		this.api.addApiOptions(getHudParam());
 		extensionHook.addApiImplementor(this.api);
 		extensionHook.addApiImplementor(this.api.getHudApiProxy());
 		extensionHook.addApiImplementor(this.api.getHudFileProxy());
@@ -167,6 +171,15 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
 	@Override
 	public void optionsLoaded() {
 	    addHudScripts();
+	    this.hudEnabled = getHudParam().isEnabled();
+	    if (View.isInitialised()) {
+	        this.getHudButton().setSelected(hudEnabled);
+	    }
+	    if (getHudParam().isDevelopmentMode()) {
+            ZAP.getEventBus().publishSyncEvent(
+                    HudEventPublisher.getPublisher(),
+                    new Event(HudEventPublisher.getPublisher(), HudEventPublisher.EVENT_DEV_MODE_ENABLED, null));
+	    }
 	}
 	
 	private void addHudScripts() {
@@ -226,6 +239,7 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
 				@Override
 				public void actionPerformed(ActionEvent e) {
 					hudEnabled = hudButton.isSelected();
+					getHudParam().setEnabled(hudEnabled);
 				}});
     	}
     	return hudButton;
@@ -265,6 +279,9 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
 	@Override
 	public boolean onHttpResponseReceive(HttpMessage msg) {
 		if (hudEnabled && msg.getResponseHeader().isHtml()) {
+			if (getHudParam().isInScopeOnly() && ! msg.isInScope()) {
+				return true;
+			}
 			try {
 				String header = msg.getResponseBody().toString();
 

--- a/src/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -68,6 +68,10 @@ public class HudAPI extends ApiImplementor {
 			"default-src 'none'; script-src 'self'; connect-src https://zap wss://zap; frame-src 'self'; img-src 'self' data:; "
 			+ "font-src 'self' data:; style-src 'self' 'unsafe-inline' ;";
 
+    protected static final String CSP_POLICY_UNSAFE_EVAL =
+            "default-src 'none'; script-src 'self' 'unsafe-eval'; connect-src https://zap wss://zap; frame-src 'self'; img-src 'self' data:; "
+            + "font-src 'self' data:; style-src 'self' 'unsafe-inline' ;";
+
     private static final String PREFIX = "hud";
     
     private Map<String, String> siteUrls = new HashMap<String, String>();
@@ -90,6 +94,8 @@ public class HudAPI extends ApiImplementor {
 	
 	private String hudFileUrl;
     private String hudApiUrl;
+
+    private String websocketUrl;
 
     private boolean isTimelineEnabled = false;
 
@@ -152,6 +158,10 @@ public class HudAPI extends ApiImplementor {
 	
 	public void reset() {
 		this.siteUrls.clear();
+	}
+	
+	public boolean allowUnsafeEval() {
+	    return this.extension.getHudParam().isDevelopmentMode() && this.extension.getHudParam().isAllowUnsafeEval();
 	}
 	
 	public boolean isTimelineEnabled() {
@@ -457,7 +467,6 @@ public class HudAPI extends ApiImplementor {
         }
     }
     
-    private String websocketUrl;
     private String getWebSocketUrl() {
         if (websocketUrl == null) {
             websocketUrl = Control.getSingleton().getExtensionLoader().getExtension(ExtensionWebSocket.class).getCallbackUrl();

--- a/src/org/zaproxy/zap/extension/hud/HudEventPublisher.java
+++ b/src/org/zaproxy/zap/extension/hud/HudEventPublisher.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2018 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License.  
+ */
+
+package org.zaproxy.zap.extension.hud;
+
+import org.zaproxy.zap.ZAP;
+import org.zaproxy.zap.eventBus.EventPublisher;
+
+public class HudEventPublisher implements EventPublisher {
+
+    private static HudEventPublisher publisher = null;
+    public static final String EVENT_DEV_MODE_ENABLED = "devMode.enabled";
+    public static final String EVENT_DEV_MODE_DISABLED = "devMode.disabled";
+
+    @Override
+    public String getPublisherName() {
+        return HudEventPublisher.class.getCanonicalName();
+    }
+
+    public static synchronized HudEventPublisher getPublisher() {
+        if (publisher == null) {
+            publisher = new HudEventPublisher();
+            ZAP.getEventBus().registerPublisher(
+                    publisher,
+                    new String[] { EVENT_DEV_MODE_ENABLED, EVENT_DEV_MODE_DISABLED });
+
+        }
+        return publisher;
+    }
+}

--- a/src/org/zaproxy/zap/extension/hud/HudFileProxy.java
+++ b/src/org/zaproxy/zap/extension/hud/HudFileProxy.java
@@ -74,7 +74,11 @@ public class HudFileProxy extends ApiImplementor {
                     msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
                     
                     if (msg.getRequestHeader().getURI().toString().startsWith(API.API_URL_S)) {
-                        msg.getResponseHeader().setHeader("Content-Security-Policy", HudAPI.CSP_POLICY);
+                        if (api.allowUnsafeEval()) {
+                            msg.getResponseHeader().setHeader("Content-Security-Policy", HudAPI.CSP_POLICY_UNSAFE_EVAL);
+                        } else {
+                            msg.getResponseHeader().setHeader("Content-Security-Policy", HudAPI.CSP_POLICY);
+                        }
                     }
 
                     

--- a/src/org/zaproxy/zap/extension/hud/HudParam.java
+++ b/src/org/zaproxy/zap/extension/hud/HudParam.java
@@ -23,6 +23,7 @@ import java.io.File;
 
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.common.VersionedAbstractParam;
+import org.zaproxy.zap.extension.api.ZapApiIgnore;
 
 public class HudParam extends VersionedAbstractParam {
 
@@ -31,7 +32,11 @@ public class HudParam extends VersionedAbstractParam {
      */
     private static final String PARAM_BASE_KEY = "hud";
 
+    private static final String PARAM_ENABLED = PARAM_BASE_KEY + ".enabled";
     private static final String PARAM_BASE_DIRECTORY = PARAM_BASE_KEY + ".dir";
+    private static final String PARAM_DEV_MODE = PARAM_BASE_KEY + ".devMode";
+    private static final String PARAM_ALLOW_UNSAFE_EVAL = PARAM_BASE_KEY + ".unsafeEval";
+    private static final String PARAM_IN_SCOPE_ONLY = PARAM_BASE_KEY + ".inScopeOnly";
 
     /**
      * The version of the configurations. Used to keep track of configurations changes between releases, if updates are needed.
@@ -42,6 +47,14 @@ public class HudParam extends VersionedAbstractParam {
     private static final int PARAM_CURRENT_VERSION = 1;
 
     private String baseDirectory;
+    
+    private boolean developmentMode;
+    
+    private boolean allowUnsafeEval;
+    
+    private boolean enabled;
+    
+    private boolean inScopeOnly;
 
     public String getBaseDirectory() {
         return baseDirectory;
@@ -50,6 +63,51 @@ public class HudParam extends VersionedAbstractParam {
     public void setBaseDirectory(String baseDirectory) {
         this.baseDirectory = baseDirectory;
         getConfig().setProperty(PARAM_BASE_DIRECTORY, baseDirectory);
+    }
+
+    
+    public boolean isDevelopmentMode() {
+        return developmentMode;
+    }
+
+    
+    public void setDevelopmentMode(boolean developmentMode) {
+        this.developmentMode = developmentMode;
+        getConfig().setProperty(PARAM_DEV_MODE, developmentMode);
+    }
+
+    
+    public boolean isAllowUnsafeEval() {
+        return allowUnsafeEval;
+    }
+
+    
+    @ZapApiIgnore   // Feels too dangerous to allow this
+    public void setAllowUnsafeEval(boolean allowUnsafeEval) {
+        this.allowUnsafeEval = allowUnsafeEval;
+        getConfig().setProperty(PARAM_ALLOW_UNSAFE_EVAL, allowUnsafeEval);
+    }
+
+    
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        getConfig().setProperty(PARAM_ENABLED, enabled);
+    }
+
+    
+    public boolean isInScopeOnly() {
+        return inScopeOnly;
+    }
+
+    
+    public void setInScopeOnly(boolean inScopeOnly) {
+        this.inScopeOnly = inScopeOnly;
+        getConfig().setProperty(PARAM_IN_SCOPE_ONLY, inScopeOnly);
     }
 
     @Override
@@ -66,6 +124,10 @@ public class HudParam extends VersionedAbstractParam {
     protected void parseImpl() {
         baseDirectory = getConfig()
                 .getString(PARAM_BASE_DIRECTORY, Constant.getZapHome() + File.separator + ExtensionHUD.DIRECTORY_NAME);
+        enabled = getConfig().getBoolean(PARAM_ENABLED, false);
+        developmentMode = getConfig().getBoolean(PARAM_DEV_MODE, false);
+        allowUnsafeEval = getConfig().getBoolean(PARAM_ALLOW_UNSAFE_EVAL, false);
+        inScopeOnly = getConfig().getBoolean(PARAM_IN_SCOPE_ONLY, false);
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/hud/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/hud/resources/Messages.properties
@@ -10,4 +10,7 @@ hud.toolbar.button.on.tooltip	= Disable the ZAP HUD
 hud.optionspanel.name	= HUD
 hud.optionspanel.button.baseDirectory	= Change
 hud.optionspanel.label.baseDirectory	= Base Directory:
+hud.optionspanel.label.inScopeOnly		= Enable the HUD only for URLs that are in scope
+hud.optionspanel.label.developmentMode	= Development mode
+hud.optionspanel.label.allowUnsafeEval	= <html>Allow unsafe evals<br><font color='red'>Only use in a safe environment for compiling templates inline</font></html>
 hud.optionspanel.warn.badBaseDir		= Base Directory either does not exist or is not readable


### PR DESCRIPTION
Fixes #38
Fixes #44

AllowUnsafeEval changes the CSP, and requires development mode.
Switching dev mode on and off generates new events.
All options are persisted, including whether the HUD is on or off.
All options are visible and settable via the API with the exception of
allowUnsafeEval - that cant be set via the API as it feels to dangerous
;)