### PR TITLE
Unregister event publisher on unload

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -170,6 +170,8 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
 	public void unload() {
 		getExtScript().removeScripType(hudScriptType);
 		getExtScript().removeListener(this);
+
+		HudEventPublisher.unregister();
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/hud/HudEventPublisher.java
+++ b/src/org/zaproxy/zap/extension/hud/HudEventPublisher.java
@@ -44,4 +44,10 @@ public class HudEventPublisher implements EventPublisher {
         }
         return publisher;
     }
+
+    static synchronized void unregister() {
+        if (publisher != null) {
+            ZAP.getEventBus().unregisterPublisher(publisher);
+        }
+    }
 }


### PR DESCRIPTION
Add a method to HudEventPublisher to allow to unregister it.
Change ExtensionHUD to call the method when unloading the extension.