### PR TITLE
Inject the tool filenames into the service worker

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -457,6 +458,22 @@ public class HudAPI extends ApiImplementor {
                 // Only do this on the ZAP domain
                 contents = contents.replace("<<ZAP_HUD_API>>", this.hudApiUrl)
                         .replace("<<ZAP_HUD_WS>>", getWebSocketUrl());
+
+                if (file.equals("serviceworker.js")) {
+                    // Inject the tool filenames
+                    StringBuilder sb = new StringBuilder();
+                    File toolsDir = new File(this.extension.getHudParam().getBaseDirectory(), "tools");
+                    for (String tool : toolsDir.list()) {
+                        if (tool.toLowerCase(Locale.ROOT).endsWith(".js")) {
+                            sb.append("\t\"");
+                            sb.append(this.hudFileUrl);
+                            sb.append("?name=tools/");
+                            sb.append(tool);
+                            sb.append("\",\n");
+                        }
+                    }
+                    contents = contents.replace("<<ZAP_HUD_TOOLS>>", sb.toString());
+                }
             }
             
             return contents;

--- a/src/org/zaproxy/zap/extension/hud/files/hud/serviceworker.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/serviceworker.js
@@ -32,22 +32,7 @@ var urlsToCache = [
 ];
 
 var toolScripts = [
-	"<<ZAP_HUD_FILES>>?name=tools/scope.js",
-	"<<ZAP_HUD_FILES>>?name=tools/spider.js",
-	"<<ZAP_HUD_FILES>>?name=tools/timeline.js",
-	"<<ZAP_HUD_FILES>>?name=tools/activeScan.js",
-	"<<ZAP_HUD_FILES>>?name=tools/pageAlerts.js",
-	"<<ZAP_HUD_FILES>>?name=tools/pageAlertsHigh.js",
-	"<<ZAP_HUD_FILES>>?name=tools/pageAlertsMedium.js",
-	"<<ZAP_HUD_FILES>>?name=tools/pageAlertsLow.js",
-	"<<ZAP_HUD_FILES>>?name=tools/pageAlertsInformational.js",
-	"<<ZAP_HUD_FILES>>?name=tools/siteAlerts.js",
-	"<<ZAP_HUD_FILES>>?name=tools/siteAlertsHigh.js",
-	"<<ZAP_HUD_FILES>>?name=tools/siteAlertsMedium.js",
-	"<<ZAP_HUD_FILES>>?name=tools/siteAlertsLow.js",
-	"<<ZAP_HUD_FILES>>?name=tools/siteAlertsInformational.js",
-	"<<ZAP_HUD_FILES>>?name=tools/break.js",
-	"<<ZAP_HUD_FILES>>?name=tools/attack.js"
+<<ZAP_HUD_TOOLS>>
 ];
 
 self.tools = {};


### PR DESCRIPTION
This is the first part of #108 - it doesnt handle the UI elements or
tools which run on the target domain.
If this approach looks good then I'll aim to implement those features in
future PRs :)