### PR TITLE
Correct response's Content-Length in HudApiProxy

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/HudApiProxy.java
+++ b/src/org/zaproxy/zap/extension/hud/HudApiProxy.java
@@ -95,7 +95,7 @@ public class HudApiProxy extends ApiImplementor {
             msg.setResponseHeader(API.getDefaultResponseHeader("application/json; charset=UTF-8", 0, false));
             String body = response.toJSON().toString();
             msg.setResponseBody(body);
-            msg.getResponseHeader().setContentLength(body.length());
+            msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
             return body;
         } catch (Exception e) {
             LOG.error("Failed at end " + e.getMessage(), e);


### PR DESCRIPTION
Change HudApiProxy to use the number of bytes (instead of number of
chars, which might be different) for the Content-Length of the response.

Related to #75 - core/view/alert/ API endpoint returns malformed json