### PR TITLE
add heartbeat from management

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/management.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/management.js
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 		// send onTargetLoad message 
 		navigator.serviceWorker.controller.postMessage({action:"onTargetLoad", targetUrl: document.referrer});
 	}
+
+	startHeartBeat();
 });
 
 navigator.serviceWorker.addEventListener('message', function(event) {
@@ -111,4 +113,13 @@ function startServiceWorker() {
 	else {
 		alert('This browser does not support Service Workers. The HUD will not work properly.')
 	}
+}
+
+/*
+ * Starts sending heart beat messages to the ZAP API every 10 seconds
+ */
+function startHeartBeat() {
+	setInterval(function() {
+		log(LOG_INFO, 'heartbeat', 'heartbeat')
+	}, 10000)
 }


### PR DESCRIPTION
Adds a simple heart beat to keep the service worker from terminating. Each fetch request to the ZAP API from the management console will trigger the fetch event listener in the service worker. This will keep the service worker continually responding to events and staying alive.

**This is a hack from the designed usage of service workers.** Service workers are designed to be short lived, ephemeral workers triggered by event handlers. The main reasons for this model are for performance and privacy. Our hack *should* be fine, but it is worth noting that our architecture goes against the intended design of the technology. 