### PR TITLE
Fix non-transparent background for management iframe

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/libraries/spectre.css
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/libraries/spectre.css
@@ -2293,7 +2293,7 @@ html {
     height: 1.3rem;
     line-height: .8rem;
     margin: .1rem;
-    min-width: 28px;
+    min-width: 26px;
     max-width: 100%;
     padding: .2rem .4rem;
     text-decoration: none;
@@ -2309,15 +2309,19 @@ html {
   }
 
   .hud-button.small {
-    min-width: 28px;
-    max-width: 28px;
+    min-width: 26px;
+    max-width: 26px;
   }
   
   .hud-button img {
     margin-left: -.15rem;
     margin-right: -.15rem;
   }
-
+  
+  .hud-button.small img {
+    margin-left: -.20rem;
+    margin-right: -.20rem;
+  }
   
   .chip {
     align-items: center;

--- a/src/org/zaproxy/zap/extension/hud/files/hud/management.css
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/management.css
@@ -1,0 +1,3 @@
+body {
+  background: none transparent;
+}

--- a/src/org/zaproxy/zap/extension/hud/files/hud/management.html
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/management.html
@@ -11,23 +11,24 @@
 <body>
 	<div id="app"> 
 		<hud-button v-show="isSettingsButtonShown" icon="<<ZAP_HUD_FILES>>?image=gear.png"></hud-button>
-		<loading-screen v-show="isLoadingScreenShown"></loading-screen>
+		<!--TODO: implement this for splash screen on first time load-->
+		<!-- <loading-screen v-show="isLoadingScreenShown"></loading-screen> -->
 	</div>
 
 	<template id="hud-button-template">
-		<div class="hud-button small" @click="click" @mouseover="showData = true" @mouseleave="showData = false">
+		<div :class="{'hud-button': true, 'small': true, 'active': isActive}" @click="click" @mouseover="mouseOver" @mouseleave="mouseLeave">
 			<img :src="icon">
 			<span>{{label}}</span>
-			<span v-show="showData">{{data}}</span>
 		</div>
 	</template>
 
 	<!-- TODO: make this a super cool loading screen -->
+	<!--
 	<template id="loading-screen-template">
 		<div>
 			<h1>The HUD is loading.</h1>
 		</div>
 	</template>
-
+	-->
 </body>
 </html>

--- a/src/org/zaproxy/zap/extension/hud/files/hud/management.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/management.js
@@ -12,13 +12,20 @@ Vue.component('hud-button', {
 	props: ['label', 'icon', 'data'],
 	data() {
 		return {
-			showData:false
+			showData: false,
+			isActive: false
 		}
 	},
 	methods: {
 		click: function() {
 			navigator.serviceWorker.controller.postMessage({action:'showHudSettings'});
 		},
+		mouseOver() {
+			this.isActive = true;
+		},
+		mouseLeave() {
+			this.isActive = false;
+		}
 	}
 })
 

--- a/src/org/zaproxy/zap/extension/hud/files/hud/target/inject.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/target/inject.js
@@ -257,7 +257,7 @@
 	if (window.top == window.self) {
 		window.addEventListener("message", receiveMessages);
 		var template = document.createElement("template");
-		template.innerHTML = '<iframe id="management" src="<<ZAP_HUD_FILES>>?name=management.html" style="position: fixed; left: 0px; top: 0px; width:50px; height:50px; border: medium none; overflow: hidden; z-index: 2147483647"></iframe>\n' +
+		template.innerHTML = '<iframe id="management" src="<<ZAP_HUD_FILES>>?name=management.html" style="position: fixed; left: 0px; top: 0px; width:28px; height:28px; border: medium none; overflow: hidden; z-index: 2147483647"></iframe>\n' +
 			'<iframe id="left-panel" src="<<ZAP_HUD_FILES>>?name=panel.html&amp;url=<<URL>>&amp;orientation=left" scrolling="no" style="position: fixed; border: medium none; top: 30%; border: medium none; left: 0px; width: 110px; height: 300px; z-index: 2147483646;"></iframe>\n' +
 			'<iframe id="right-panel" src="<<ZAP_HUD_FILES>>?name=panel.html&amp;url=<<URL>>&amp;orientation=right" scrolling="no" style="position: fixed; border: medium none; top: 30%; overflow: hidden; right: 0px; width: 110px; height: 300px; z-index: 2147483646;"></iframe>\n' +
 			'<iframe id="main-display" src="<<ZAP_HUD_FILES>>?name=display.html" style="position: fixed; right: 0px; top: 0px; width: 100%; height: 100%; border: 0px none; display: none; z-index: 2147483647;"></iframe>\n' +


### PR DESCRIPTION
Change include:
- adding transparent background to management.css
- tightening up management iframe size in inject
- adding  a mouseover effect on the management button
- changed the css on small hud buttons