### PR TITLE
Fix Growler Alert Frame Size/ Queue

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/target/inject.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/target/inject.js
@@ -87,16 +87,18 @@
 	}
 
 	/* dynamically size growler iframes with number of alerts */
-	function heightenGrowlerFrame() {
+	function heightenGrowlerFrame(lines) {
 		var panel = document.getElementById("growler-alerts");
+		var offset = 56 + 30 * lines;
 
-		panel.style.height = (panel.offsetHeight + 55) + "px";
+		panel.style.height = (panel.offsetHeight + offset) + "px";
 	}
 
-	function shortenGrowlerFrame() {
+	function shortenGrowlerFrame(lines) {
 		var panel = document.getElementById("growler-alerts");
+		var offset = 56 + 30 * lines;
 
-		panel.style.height = (panel.offsetHeight - 55) + "px";
+		panel.style.height = (panel.offsetHeight - offset) + "px";
 	}
 
 	/* dynamically size iframes with number of buttons */
@@ -212,7 +214,6 @@
 				break;
 
 			case "expandManagement":
-				console.log('expanding management')
 				expandManagement();
 				break;
 
@@ -233,11 +234,11 @@
 				break;
 
 			case "heightenGrowlerFrame":
-				heightenGrowlerFrame();
+				heightenGrowlerFrame(message.lines);
 				break;
 
 			case "shortenGrowlerFrame":
-				shortenGrowlerFrame();
+				shortenGrowlerFrame(message.lines);
 				break;
 
 			case "showEnable.on":
@@ -261,7 +262,7 @@
 			'<iframe id="left-panel" src="<<ZAP_HUD_FILES>>?name=panel.html&amp;url=<<URL>>&amp;orientation=left" scrolling="no" style="position: fixed; border: medium none; top: 30%; border: medium none; left: 0px; width: 110px; height: 300px; z-index: 2147483646;"></iframe>\n' +
 			'<iframe id="right-panel" src="<<ZAP_HUD_FILES>>?name=panel.html&amp;url=<<URL>>&amp;orientation=right" scrolling="no" style="position: fixed; border: medium none; top: 30%; overflow: hidden; right: 0px; width: 110px; height: 300px; z-index: 2147483646;"></iframe>\n' +
 			'<iframe id="main-display" src="<<ZAP_HUD_FILES>>?name=display.html" style="position: fixed; right: 0px; top: 0px; width: 100%; height: 100%; border: 0px none; display: none; z-index: 2147483647;"></iframe>\n' +
-			'<iframe id="growler-alerts" src="<<ZAP_HUD_FILES>>?name=growlerAlerts.html" style="position: fixed; right: 0px; bottom: 0px; width: 500px; height: 0px; border: 0px none; z-index: 2147483647;"></iframe>';
+			'<iframe id="growler-alerts" src="<<ZAP_HUD_FILES>>?name=growlerAlerts.html" style="position: fixed; right: 0px; bottom: 0px; width: 500px; height: 0px;border: 0px none; z-index: 2147483647;"></iframe>';
 		document.body.appendChild(template.content);
 	}
 })();


### PR DESCRIPTION
Two issues were fixed here:
1. In order to show each growler alert for a set amount of time (so that each alert can be seen), while also only showing a maximum number of growler alerts (so that they don't cover half the page) we need to queue the alerts. Alertify doesn't offer any support for queueing growler alerts, so I had to implement the logic of scheduling the growler alerts.

2. When alert messages stretch beyond one line, the growler alert height changes, changing the size we need to increase the iframe by. I did some trial-and-error testing to figure out roughly how long a message would need to be to strech multple lines in the growler so we could properly scale the iframe.

fixes #125 fixes #66