### PR TITLE
Correct the page alert counts

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/pageAlertsHigh.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/pageAlertsHigh.js
@@ -39,10 +39,6 @@ var PageAlertsHigh = (function() {
 		alertUtils.showPageAlerts(LABEL, url, ALERT_RISK);
 	}
 
-	function updateAlertCount(url) {
-		return alertUtils.updateAlertCount(NAME, url);
-	}
-
 	function onPanelLoad(data) {
 	}
 
@@ -56,6 +52,10 @@ var PageAlertsHigh = (function() {
 
 	self.addEventListener("commonAlerts." + ALERT_RISK, function(event) {
 		return alertUtils.updatePageAlertCount(NAME, targetUrl, ALERT_RISK);
+	});
+
+	self.addEventListener("targetload", function(event) {
+		return alertUtils.updatePageAlertCount(NAME, event.detail.url, ALERT_RISK);
 	});
 
 	self.addEventListener("message", function(event) {

--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/pageAlertsInformational.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/pageAlertsInformational.js
@@ -39,10 +39,6 @@ var PageAlertsInformational = (function() {
 		alertUtils.showPageAlerts(LABEL, url, ALERT_RISK);
 	}
 
-	function updateAlertCount(url) {
-		return alertUtils.updateAlertCount(NAME, url);
-	}
-
 	function onPanelLoad(data) {
 	}
 
@@ -56,6 +52,10 @@ var PageAlertsInformational = (function() {
 
 	self.addEventListener("commonAlerts." + ALERT_RISK, function(event) {
 		return alertUtils.updatePageAlertCount(NAME, targetUrl, ALERT_RISK);
+	});
+
+	self.addEventListener("targetload", function(event) {
+		return alertUtils.updatePageAlertCount(NAME, event.detail.url, ALERT_RISK);
 	});
 
 	self.addEventListener("message", function(event) {

--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/pageAlertsLow.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/pageAlertsLow.js
@@ -39,10 +39,6 @@ var PageAlertsLow = (function() {
 		alertUtils.showPageAlerts(LABEL, url, ALERT_RISK);
 	}
 
-	function updateAlertCount(url) {
-		return alertUtils.updateAlertCount(NAME, url);
-	}
-
 	function showOptions() {
 		alertUtils.showOptions(NAME, LABEL)
 	}
@@ -53,6 +49,10 @@ var PageAlertsLow = (function() {
 
 	self.addEventListener("commonAlerts." + ALERT_RISK, function(event) {
 		return alertUtils.updatePageAlertCount(NAME, targetUrl, ALERT_RISK);
+	});
+
+	self.addEventListener("targetload", function(event) {
+		return alertUtils.updatePageAlertCount(NAME, event.detail.url, ALERT_RISK);
 	});
 
 	self.addEventListener("message", function(event) {

--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/pageAlertsMedium.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/pageAlertsMedium.js
@@ -39,10 +39,6 @@ var PageAlertsMedium = (function() {
 		alertUtils.showPageAlerts(LABEL, url, ALERT_RISK);
 	}
 
-	function updateAlertCount(url) {
-		return alertUtils.updateAlertCount(NAME, url);
-	}
-
 	function onPanelLoad(data) {
 	}
 
@@ -56,6 +52,10 @@ var PageAlertsMedium = (function() {
 
 	self.addEventListener("commonAlerts." + ALERT_RISK, function(event) {
 		return alertUtils.updatePageAlertCount(NAME, targetUrl, ALERT_RISK);
+	});
+
+	self.addEventListener("targetload", function(event) {
+		return alertUtils.updatePageAlertCount(NAME, event.detail.url, ALERT_RISK);
 	});
 
 	self.addEventListener("message", function(event) {


### PR DESCRIPTION
Fixes the problem with the page counts being wrong in #120 as it recalculates them when the page loads.
It wont address any other alert count related issues, so worth leaving that bug open until we've had a chance to look into it in more detail?