### PR TITLE
Show the number of hidden fields

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.io.IOUtils;
@@ -83,6 +84,11 @@ public class HudAPI extends ApiImplementor {
     private String websocketUrl;
 
     private boolean isTimelineEnabled = false;
+    
+    /**
+     * Shared secret used to ensure that we only accept messages from the ZAP code running on the target domain
+     */
+    private final String sharedSecret = UUID.randomUUID().toString();
 
     private static Logger logger = Logger.getLogger(HudAPI.class);
     
@@ -236,8 +242,10 @@ public class HudAPI extends ApiImplementor {
                 // Strip off the callback path
                 url = url.substring(0, url.indexOf("/zapCallBackUrl"));
             }
-            contents = contents.replace("<<ZAP_HUD_FILES>>", this.hudFileUrl)
-                    .replace("<<URL>>", url);
+            contents = contents
+                    .replace("<<ZAP_HUD_FILES>>", this.hudFileUrl)
+                    .replace("<<URL>>", url)
+                    .replace("<<ZAP_SHARED_SECRET>>", this.sharedSecret);
 
             if (url.startsWith(API.API_URL_S)) {
                 // Only do this on the ZAP domain

--- a/src/org/zaproxy/zap/extension/hud/files/hud/management.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/management.js
@@ -66,6 +66,25 @@ document.addEventListener('DOMContentLoaded', function() {
 	startHeartBeat();
 });
 
+
+/*
+ * Receive messages from the target domain, which is not trusted.
+ * As a result we only accept messages that contain a shared secret generated and injected at runtime.
+ * The contents of the messages should still be treated as potentially malicious.
+ */
+window.addEventListener('message', function(event) {
+	if (! event.data.hasOwnProperty('sharedSecret')) {
+		log(LOG_WARN, 'management.receiveMessage', 'Message without sharedSecret rejected');
+		return;
+	}
+	if (event.data.sharedSecret === "<<ZAP_SHARED_SECRET>>") {
+		navigator.serviceWorker.controller.postMessage(event.data);
+	} else {
+		log(LOG_WARN, 'management.receiveMessage', 'Message with incorrect sharedSecret rejected ' + event.data.sharedSecret);
+	}
+});
+
+
 navigator.serviceWorker.addEventListener('message', function(event) {
 	var message = event.data;
 	
@@ -88,6 +107,10 @@ navigator.serviceWorker.addEventListener('message', function(event) {
 
 		case 'showEnable.off':
 			parent.postMessage({action: 'showEnable.off'}, document.referrer);
+			break;
+
+		case 'showEnable.count':
+			parent.postMessage({action: 'showEnable.count'}, document.referrer);
 			break;
 
 		default:

--- a/src/org/zaproxy/zap/extension/hud/files/hud/target/inject.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/target/inject.js
@@ -134,6 +134,8 @@
 	}
 	
 	// TODO put this code in a separate file and inject ?
+	var showEnabled = false;
+	var showEnabledCount = 0;
 	var showEnableTypeHiddenFields = [];
 	var showEnableDisplayNoneFields = [];
 	var showEnableDisplayHiddenFields = [];
@@ -143,19 +145,31 @@
 
 		inputs = document.getElementsByTagName('input');
 		for (index = 0; index < inputs.length; ++index) {
+			var counted = false;
 			if (inputs[index].type == "hidden") {
 				inputs[index].type = "";
 				showEnableTypeHiddenFields.push(inputs[index]);
+				showEnabledCount++;
+				counted = true;
 			}
 			if (inputs[index].style.display == "none") {
 				inputs[index].style.display = "";
 				showEnableDisplayNoneFields.push(inputs[index]);
+				if (! counted) {
+					showEnabledCount++;
+					counted = true;
+				}
 			}
 			if (inputs[index].style.visibility == "hidden") {
 				inputs[index].style.visibility = "";
 				showEnableTypeHiddenFields.push(inputs[index]);
+				if (! counted) {
+					showEnabledCount++;
+					counted = true;
+				}
 			}
 		}
+		showEnabled = true;
 	}
 
 	function showEnableOff() {
@@ -171,8 +185,36 @@
 		for (index = 0; index < showEnableDisplayHiddenFields.length; ++index) {
 			showEnableDisplayHiddenFields[index].style.visibility = 'hidden';
 		}
+		showEnableTypeHiddenFields = [];
+		showEnableDisplayNoneFields = [];
 		showEnableDisplayHiddenFields = [];
+		showEnabled = false;
+		showEnabledCount = 0
 	}
+	
+
+	function showEnableCount() {
+		var count = 0;
+		if (showEnabled) {
+			count = showEnabledCount;
+		} else {
+			// Count the number of hidden fields
+			var inputs = document.getElementsByTagName('input');
+			for (index = 0; index < inputs.length; ++index) {
+				if (inputs[index].type == "hidden") {
+					count++;
+				} else if (inputs[index].style.display == "none") {
+					count++;
+				} else if (inputs[index].style.visibility == "hidden") {
+					count++;
+				}
+			}
+		}
+		// Send to the management frame with the shared secret
+		var iframe = document.getElementById("management");
+		iframe.contentWindow.postMessage({action: 'showEnable.count', count: count, sharedSecret: "<<ZAP_SHARED_SECRET>>"}, "<<ZAP_HUD_FILES>>");
+	}
+
 
 	/* COMMUNICATIONS */
 	function receiveMessages (event) {
@@ -247,6 +289,10 @@
 
 			case "showEnable.off":
 				showEnableOff();
+				break;
+
+			case "showEnable.count":
+				showEnableCount();
 				break;
 
 			default:

--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/showEnable.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/showEnable.js
@@ -11,8 +11,6 @@ var ShowEnable = (function() {
 	var NAME = "showEnable";
 	var LABEL = "Show / Enable";
 	var DATA = {};
-		DATA.OFF = "Off";
-		DATA.ON = "On";
 	var ICONS = {};
 		ICONS.OFF = "show-off.png";
 		ICONS.ON = "show-on.png";
@@ -22,12 +20,13 @@ var ShowEnable = (function() {
 		var tool = {};
 		tool.name = NAME;
 		tool.label = LABEL;
-		tool.data = DATA.OFF;
+		tool.data = 0;
 		tool.icon = ICONS.OFF;
 		tool.isSelected = false;
 		tool.isRunning = false;
 		tool.panel = "";
 		tool.position = 0;
+		tool.count = 0;
 
 		saveTool(tool);
 	}
@@ -61,7 +60,6 @@ var ShowEnable = (function() {
 		loadTool(NAME)
 			.then(function(tool) {
 				tool.isRunning = true;
-				tool.data = DATA.ON;
 				tool.icon = ICONS.ON;
 
 				saveTool(tool);
@@ -75,9 +73,17 @@ var ShowEnable = (function() {
 		loadTool(NAME)
 			.then(function(tool) {
 				tool.isRunning = false;
-				tool.data = DATA.OFF;
 				tool.icon = ICONS.OFF;
 
+				saveTool(tool);
+			})
+			.catch(errorHandler);
+	}
+	
+	function setCount(count) {
+		loadTool(NAME)
+			.then(function(tool) {
+				tool.data = count;
 				saveTool(tool);
 			})
 			.catch(errorHandler);
@@ -116,6 +122,8 @@ var ShowEnable = (function() {
 					else {
 						switchOff();
 					}
+					// Ask for the count of hidden fields
+					messageFrame("management", {action:"showEnable.count"});
 				})
 				.catch(errorHandler);
 	});
@@ -127,6 +135,13 @@ var ShowEnable = (function() {
 		switch(message.action) {
 			case "initializeTools":
 				initializeStorage();
+				break;
+
+			case "showEnable.count":
+				// Check its an int - its been supplied by the target domain so in theory could have been tampered with
+				if (message.count === parseInt(message.count, 10)) {
+					setCount(message.count);
+				}
 				break;
 
 			default:


### PR DESCRIPTION
This change adds support for sending messages from the untrusted target domain to the HUD domain.
A shared secret is used which should not be accessible to the target domain, but messages from that domain should still be treated as potentially malicious,