### PR TITLE
Alert event performance improvements

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/alertUtils.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/alertUtils.js
@@ -109,8 +109,12 @@ var alertUtils = (function() {
 	function updateAlertCount(toolname, count) {
 		loadTool(toolname)
 			.then(function(tool) {
-				tool.data = count;
-				return saveTool(tool);
+				if (tool.data == count) {
+					log (LOG_TRACE, 'alertUtils.updateAlertCount no save needed');
+				} else {
+					tool.data = count;
+					return saveTool(tool);
+				}
 			})
 			.catch(errorHandler);
 	}


### PR DESCRIPTION
The performance issues can be reproduced by spidering bodgeit via the HUD, ideally with all of the pscan rules installed.
As ZAP processes the pscan queue a large number of alert events are sent to the HUD (~3500 in my case). The HUD became slower and slower before often locking up.
The issue turned out to be the number of time we were saving data to indexdb.
There are 2 parts to this fix:

1. Not saving a tool if the data hasnt changed (an easy win)
1. Processing the alert events in batches - often only 1 or 2 events will be processed at one time but I've seen 70+ also been handled, which makes a significant difference.