### PR TITLE
Make better use of `console` logging

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/utils.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/utils.js
@@ -616,24 +616,24 @@ function errorHandler(err) {
 }
 
 function log(level, method, message, object) {
-  if (level > LOG_LEVEL || (! LOG_TO_CONSOLE && ! LOG_TO_ZAP)) {
-    return;
-  }
+	if (level > LOG_LEVEL || (! LOG_TO_CONSOLE && ! LOG_TO_ZAP)) {
+		return;
+	}
 
-  const logLevel = LOG_STRS[level];
+	const logLevel = LOG_STRS[level];
 
-  var record = new Date().toTimeString() + ' ' + logLevel + ' ' + method + ': ' + message;
-  if (object) {
-    record += ': ' + JSON.stringify(object);
-  }
+	var record = new Date().toTimeString() + ' ' + logLevel + ' ' + method + ': ' + message;
+	if (object) {
+		record += ': ' + JSON.stringify(object);
+	}
 
-  if (LOG_TO_CONSOLE) {
-    if (logLevel == 'OFF' || logLevel == 'TRACE') {
-      logLevel = 'LOG';
-    }
-    console[logLevel.toLowerCase()](record);
-  }
-  if (LOG_TO_ZAP) {
-    fetch("<<ZAP_HUD_API>>/hud/action/log/?record=" + record);
-  }
+	if (LOG_TO_CONSOLE) {
+		if (logLevel == 'OFF' || logLevel == 'TRACE') {
+			logLevel = 'LOG';
+		}
+		console[logLevel.toLowerCase()](record);
+	}
+	if (LOG_TO_ZAP) {
+		fetch("<<ZAP_HUD_API>>/hud/action/log/?record=" + record);
+	}
 }


### PR DESCRIPTION
  * to avoid flood in the browser
  * keep same format between `ZAP` and `console` logs

Fixes #141