### PR TITLE
new nav-modal to go 'back' to a previous modal

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/hud/ZapAddOn.xml
@@ -27,6 +27,7 @@
 		<file>hud/libraries/alertify.js</file>
 		<file>hud/libraries/localforage.min.js</file>
 		<file>hud/libraries/spectre.css</file>
+		<file>hud/libraries/spectre-icons.css</file>
 		<file>hud/libraries/vue.js</file>
 		<file>hud/management.css</file>
 		<file>hud/management.html</file>

--- a/src/org/zaproxy/zap/extension/hud/files/hud/display.html
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/display.html
@@ -1,6 +1,7 @@
 <html>
     <head>   
         <link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=libraries/spectre.css"/>
+        <link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=libraries/spectre-icons.css"/>
         <link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=display.css"/>
 
         <script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=libraries/vue.js"></script>
@@ -27,6 +28,7 @@
                 <a href="#close" class="modal-overlay" aria-label="Close" @click="close"></a>
                 <div class="modal-container">
                     <div class="modal-header">
+                        <slot name="header"></slot>
                         <a href="#close" class="btn btn-clear float-right" aria-label="Close" @click="close"></a>
                         <div class="modal-title h5">{{title}}</div>
                     </div>
@@ -41,6 +43,22 @@
                 </div>
             </div>
             </transition>
+        </template>
+
+        <template id="nav-modal-template">
+            <modal :title="title" :show="show" @close="close">
+                <div slot="header">
+                    <button class="btn btn-action btn-sm float-left"  @click="back">
+                        <i class="icon icon-back"></i>
+                    </button>
+                </div>
+                <div slot="body">
+                    <slot name="body"></slot>
+                </div>
+                <div slot="footer">
+                    <slot name="footer"></slot>
+                </div>
+            </modal>
         </template>
 
         <!-- a simple dialog modal component -->
@@ -136,7 +154,7 @@
 
         <!-- alert details component -->
         <template id="alert-details-modal-template">
-            <modal :title="title" :show="show" @close="close">
+            <nav-modal :title="title" :show="show" @close="close" @back="back">
                 <div slot="body">
                     <table class="table table-striped table-hover">
                         <tbody>
@@ -147,7 +165,7 @@
                         </tbody>
                     </table>
                 </div>
-            </modal>
+            </nav-modal>
         </template>
 
         <!-- simple menu modal component -->

--- a/src/org/zaproxy/zap/extension/hud/files/hud/display.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/display.js
@@ -41,6 +41,19 @@ Vue.component('modal', {
 	}
 })
 
+Vue.component('nav-modal', {
+	template: '#nav-modal-template',
+	props: ['show', 'title', 'text'],
+	methods: {
+		close: function () {
+			this.$emit('close');
+		},
+		back() {
+			this.$emit('back');
+		},
+	}
+})
+
 Vue.component('dialog-modal', {
 	template: '#dialog-modal-template',
 	props: ['show', 'title', 'text'],
@@ -202,6 +215,11 @@ Vue.component('alert-details-modal', {
 	methods: {
 		close: function() {
 			this.$emit('close');
+		},
+		back: function() {
+			app.keepShowing = true;
+			app.isAlertDetailsModalShown = false;
+			this.port.postMessage({'back': true});
 		}
 	},
 	data() {

--- a/src/org/zaproxy/zap/extension/hud/files/hud/libraries/spectre-icons.css
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/libraries/spectre-icons.css
@@ -1,0 +1,619 @@
+/*! Spectre.css Icons v0.5.3 | MIT License | github.com/picturepan2/spectre */
+.icon {
+    box-sizing: border-box;
+    display: inline-block;
+    font-size: inherit;
+    font-style: normal;
+    height: 1em;
+    position: relative;
+    text-indent: -9999px;
+    vertical-align: middle;
+    width: 1em;
+  }
+  
+  .icon::before,
+  .icon::after {
+    display: block;
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+  
+  .icon.icon-2x {
+    font-size: 1.6rem;
+  }
+  
+  .icon.icon-3x {
+    font-size: 2.4rem;
+  }
+  
+  .icon.icon-4x {
+    font-size: 3.2rem;
+  }
+  
+  .accordion .icon,
+  .btn .icon,
+  .toast .icon,
+  .menu .icon {
+    vertical-align: -10%;
+  }
+  
+  .btn-lg .icon {
+    vertical-align: -15%;
+  }
+  
+  .icon-arrow-down::before,
+  .icon-arrow-left::before,
+  .icon-arrow-right::before,
+  .icon-arrow-up::before,
+  .icon-downward::before,
+  .icon-back::before,
+  .icon-forward::before,
+  .icon-upward::before {
+    border: .1rem solid currentColor;
+    border-bottom: 0;
+    border-right: 0;
+    content: "";
+    height: .65em;
+    width: .65em;
+  }
+  
+  .icon-arrow-down::before {
+    transform: translate(-50%, -75%) rotate(225deg);
+  }
+  
+  .icon-arrow-left::before {
+    transform: translate(-25%, -50%) rotate(-45deg);
+  }
+  
+  .icon-arrow-right::before {
+    transform: translate(-75%, -50%) rotate(135deg);
+  }
+  
+  .icon-arrow-up::before {
+    transform: translate(-50%, -25%) rotate(45deg);
+  }
+  
+  .icon-back::after,
+  .icon-forward::after {
+    background: currentColor;
+    content: "";
+    height: .1rem;
+    width: .8em;
+  }
+  
+  .icon-downward::after,
+  .icon-upward::after {
+    background: currentColor;
+    content: "";
+    height: .8em;
+    width: .1rem;
+  }
+  
+  .icon-back::after {
+    left: 55%;
+  }
+  
+  .icon-back::before {
+    transform: translate(-50%, -50%) rotate(-45deg);
+  }
+  
+  .icon-downward::after {
+    top: 45%;
+  }
+  
+  .icon-downward::before {
+    transform: translate(-50%, -50%) rotate(-135deg);
+  }
+  
+  .icon-forward::after {
+    left: 45%;
+  }
+  
+  .icon-forward::before {
+    transform: translate(-50%, -50%) rotate(135deg);
+  }
+  
+  .icon-upward::after {
+    top: 55%;
+  }
+  
+  .icon-upward::before {
+    transform: translate(-50%, -50%) rotate(45deg);
+  }
+  
+  .icon-caret::before {
+    border-left: .3em solid transparent;
+    border-right: .3em solid transparent;
+    border-top: .3em solid currentColor;
+    content: "";
+    height: 0;
+    transform: translate(-50%, -25%);
+    width: 0;
+  }
+  
+  .icon-menu::before {
+    background: currentColor;
+    box-shadow: 0 -.35em, 0 .35em;
+    content: "";
+    height: .1rem;
+    width: 100%;
+  }
+  
+  .icon-apps::before {
+    background: currentColor;
+    box-shadow: -.35em -.35em, -.35em 0, -.35em .35em, 0 -.35em, 0 .35em, .35em -.35em, .35em 0, .35em .35em;
+    content: "";
+    height: 3px;
+    width: 3px;
+  }
+  
+  .icon-resize-horiz::before,
+  .icon-resize-horiz::after,
+  .icon-resize-vert::before,
+  .icon-resize-vert::after {
+    border: .1rem solid currentColor;
+    border-bottom: 0;
+    border-right: 0;
+    content: "";
+    height: .45em;
+    width: .45em;
+  }
+  
+  .icon-resize-horiz::before,
+  .icon-resize-vert::before {
+    transform: translate(-50%, -90%) rotate(45deg);
+  }
+  
+  .icon-resize-horiz::after,
+  .icon-resize-vert::after {
+    transform: translate(-50%, -10%) rotate(225deg);
+  }
+  
+  .icon-resize-horiz::before {
+    transform: translate(-90%, -50%) rotate(-45deg);
+  }
+  
+  .icon-resize-horiz::after {
+    transform: translate(-10%, -50%) rotate(135deg);
+  }
+  
+  .icon-more-horiz::before,
+  .icon-more-vert::before {
+    background: currentColor;
+    border-radius: 50%;
+    box-shadow: -.4em 0, .4em 0;
+    content: "";
+    height: 3px;
+    width: 3px;
+  }
+  
+  .icon-more-vert::before {
+    box-shadow: 0 -.4em, 0 .4em;
+  }
+  
+  .icon-plus::before,
+  .icon-minus::before,
+  .icon-cross::before {
+    background: currentColor;
+    content: "";
+    height: .1rem;
+    width: 100%;
+  }
+  
+  .icon-plus::after,
+  .icon-cross::after {
+    background: currentColor;
+    content: "";
+    height: 100%;
+    width: .1rem;
+  }
+  
+  .icon-cross::before {
+    width: 100%;
+  }
+  
+  .icon-cross::after {
+    height: 100%;
+  }
+  
+  .icon-cross::before,
+  .icon-cross::after {
+    transform: translate(-50%, -50%) rotate(45deg);
+  }
+  
+  .icon-check::before {
+    border: .1rem solid currentColor;
+    border-right: 0;
+    border-top: 0;
+    content: "";
+    height: .5em;
+    transform: translate(-50%, -75%) rotate(-45deg); 
+    width: .9em;
+  }
+  
+  .icon-stop {
+    border: .1rem solid currentColor;
+    border-radius: 50%;
+  }
+  
+  .icon-stop::before {
+    background: currentColor;
+    content: "";
+    height: .1rem;
+    transform: translate(-50%, -50%) rotate(45deg);
+    width: 1em;
+  }
+  
+  .icon-shutdown {
+    border: .1rem solid currentColor;
+    border-radius: 50%;
+    border-top-color: transparent;
+  }
+  
+  .icon-shutdown::before {
+    background: currentColor;
+    content: "";
+    height: .5em;
+    top: .1em;
+    width: .1rem;
+  }
+  
+  .icon-refresh::before {
+    border: .1rem solid currentColor;
+    border-radius: 50%;
+    border-right-color: transparent;
+    content: "";
+    height: 1em;
+    width: 1em;
+  }
+  
+  .icon-refresh::after {
+    border: .2em solid currentColor;
+    border-left-color: transparent;
+    border-top-color: transparent;
+    content: "";
+    height: 0;
+    left: 80%;
+    top: 20%;
+    width: 0;
+  }
+  
+  .icon-search::before {
+    border: .1rem solid currentColor;
+    border-radius: 50%;
+    content: "";
+    height: .75em;
+    left: 5%;
+    top: 5%;
+    transform: translate(0, 0) rotate(45deg);
+    width: .75em;
+  }
+  
+  .icon-search::after {
+    background: currentColor;
+    content: "";
+    height: .1rem;
+    left: 80%;
+    top: 80%;
+    transform: translate(-50%, -50%) rotate(45deg);
+    width: .4em;
+  }
+  
+  .icon-edit::before {
+    border: .1rem solid currentColor;
+    content: "";
+    height: .4em;
+    transform: translate(-40%, -60%) rotate(-45deg);
+    width: .85em;
+  }
+  
+  .icon-edit::after {
+    border: .15em solid currentColor;
+    border-right-color: transparent;
+    border-top-color: transparent;
+    content: "";
+    height: 0;
+    left: 5%;
+    top: 95%;
+    transform: translate(0, -100%);
+    width: 0;
+  }
+  
+  .icon-delete::before {
+    border: .1rem solid currentColor;
+    border-bottom-left-radius: .1rem;
+    border-bottom-right-radius: .1rem;
+    border-top: 0;
+    content: "";
+    height: .75em;
+    top: 60%;
+    width: .75em;
+  }
+  
+  .icon-delete::after {
+    background: currentColor;
+    box-shadow: -.25em .2em, .25em .2em;
+    content: "";
+    height: .1rem;
+    top: .05rem;
+    width: .5em;
+  }
+  
+  .icon-share {
+    border: .1rem solid currentColor;
+    border-radius: .1rem;
+    border-right: 0;
+    border-top: 0;
+  }
+  
+  .icon-share::before {
+    border: .1rem solid currentColor;
+    border-left: 0;
+    border-top: 0;
+    content: "";
+    height: .4em;
+    left: 100%;
+    top: .25em;
+    transform: translate(-125%, -50%) rotate(-45deg);
+    width: .4em;
+  }
+  
+  .icon-share::after {
+    border: .1rem solid currentColor;
+    border-bottom: 0;
+    border-radius: 75% 0;
+    border-right: 0;
+    content: "";
+    height: .5em;
+    width: .6em;
+  }
+  
+  .icon-flag::before {
+    background: currentColor;
+    content: "";
+    height: 1em;
+    left: 15%;
+    width: .1rem;
+  }
+  
+  .icon-flag::after {
+    border: .1rem solid currentColor;
+    border-bottom-right-radius: .1rem;
+    border-left: 0;
+    border-top-right-radius: .1rem;
+    content: "";
+    height: .65em;
+    left: 60%;
+    top: 35%;
+    width: .8em;
+  }
+  
+  .icon-bookmark::before {
+    border: .1rem solid currentColor;
+    border-bottom: 0;
+    border-top-left-radius: .1rem;
+    border-top-right-radius: .1rem;
+    content: "";
+    height: .9em;
+    width: .8em;
+  }
+  
+  .icon-bookmark::after {
+    border: .1rem solid currentColor;
+    border-bottom: 0;
+    border-left: 0;
+    border-radius: .1rem;
+    content: "";
+    height: .5em;
+    transform: translate(-50%, 35%) rotate(-45deg) skew(15deg, 15deg);
+    width: .5em;
+  }
+  
+  .icon-download,
+  .icon-upload {
+    border-bottom: .1rem solid currentColor;
+  }
+  
+  .icon-download::before,
+  .icon-upload::before {
+    border: .1rem solid currentColor;
+    border-bottom: 0;
+    border-right: 0;
+    content: "";
+    height: .5em;
+    transform: translate(-50%, -60%) rotate(-135deg); 
+    width: .5em;
+  }
+  
+  .icon-download::after,
+  .icon-upload::after {
+    background: currentColor;
+    content: "";
+    height: .6em;
+    top: 40%;
+    width: .1rem;
+  }
+  
+  .icon-upload::before {
+    transform: translate(-50%, -60%) rotate(45deg);
+  }
+  
+  .icon-upload::after {
+    top: 50%;
+  }
+  
+  .icon-time {
+    border: .1rem solid currentColor;
+    border-radius: 50%;
+  }
+  
+  .icon-time::before {
+    background: currentColor;
+    content: "";
+    height: .4em;
+    transform: translate(-50%, -75%);
+    width: .1rem;
+  }
+  
+  .icon-time::after {
+    background: currentColor;
+    content: "";
+    height: .3em;
+    transform: translate(-50%, -75%) rotate(90deg);
+    transform-origin: 50% 90%;
+    width: .1rem;
+  }
+  
+  .icon-mail::before {
+    border: .1rem solid currentColor;
+    border-radius: .1rem;
+    content: "";
+    height: .8em;
+    width: 1em;
+  }
+  
+  .icon-mail::after {
+    border: .1rem solid currentColor;
+    border-right: 0;
+    border-top: 0;
+    content: "";
+    height: .5em;
+    transform: translate(-50%, -90%) rotate(-45deg) skew(10deg, 10deg);
+    width: .5em;
+  }
+  
+  .icon-people::before {
+    border: .1rem solid currentColor;
+    border-radius: 50%;
+    content: "";
+    height: .45em;
+    top: 25%;
+    width: .45em;
+  }
+  
+  .icon-people::after {
+    border: .1rem solid currentColor;
+    border-radius: 50% 50% 0 0;
+    content: "";
+    height: .4em;
+    top: 75%;
+    width: .9em;
+  }
+  
+  .icon-message {
+    border: .1rem solid currentColor;
+    border-bottom: 0;
+    border-radius: .1rem;
+    border-right: 0;
+  }
+  
+  .icon-message::before {
+    border: .1rem solid currentColor;
+    border-bottom-right-radius: .1rem;
+    border-left: 0;
+    border-top: 0;
+    content: "";
+    height: .8em;
+    left: 65%;
+    top: 40%;
+    width: .7em;
+  }
+  
+  .icon-message::after {
+    background: currentColor;
+    border-radius: .1rem;
+    content: "";
+    height: .3em;
+    left: 10%;
+    top: 100%;
+    transform: translate(0, -90%) rotate(45deg);
+    width: .1rem;
+  }
+  
+  .icon-photo {
+    border: .1rem solid currentColor;
+    border-radius: .1rem;
+  }
+  
+  .icon-photo::before {
+    border: .1rem solid currentColor;
+    border-radius: 50%;
+    content: "";
+    height: .25em;
+    left: 35%;
+    top: 35%;
+    width: .25em;
+  }
+  
+  .icon-photo::after {
+    border: .1rem solid currentColor;
+    border-bottom: 0;
+    border-left: 0;
+    content: "";
+    height: .5em;
+    left: 60%;
+    transform: translate(-50%, 25%) rotate(-45deg);
+    width: .5em;
+  }
+  
+  .icon-link::before,
+  .icon-link::after {
+    border: .1rem solid currentColor;
+    border-radius: 5em 0 0 5em;
+    border-right: 0;
+    content: "";
+    height: .5em;
+    width: .75em;
+  }
+  
+  .icon-link::before {
+    transform: translate(-70%, -45%) rotate(-45deg);
+  }
+  
+  .icon-link::after {
+    transform: translate(-30%, -55%) rotate(135deg);
+  }
+  
+  .icon-location::before {
+    border: .1rem solid currentColor;
+    border-radius: 50% 50% 50% 0;
+    content: "";
+    height: .8em;
+    transform: translate(-50%, -60%) rotate(-45deg);
+    width: .8em;
+  }
+  
+  .icon-location::after {
+    border: .1rem solid currentColor;
+    border-radius: 50%;
+    content: "";
+    height: .2em;
+    transform: translate(-50%, -80%);
+    width: .2em;
+  }
+  
+  .icon-emoji {
+    border: .1rem solid currentColor;
+    border-radius: 50%;
+  }
+  
+  .icon-emoji::before {
+    border-radius: 50%;
+    box-shadow: -.17em -.15em, .17em -.15em;
+    content: "";
+    height: .1em;
+    width: .1em;
+  }
+  
+  .icon-emoji::after {
+    border: .1rem solid currentColor;
+    border-bottom-color: transparent;
+    border-radius: 50%;
+    border-right-color: transparent;
+    content: "";
+    height: .5em;
+    transform: translate(-50%, -40%) rotate(-135deg);
+    width: .5em;
+  }

--- a/src/org/zaproxy/zap/extension/hud/files/hud/libraries/spectre.css
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/libraries/spectre.css
@@ -2569,6 +2569,10 @@ html {
     text-align: right;
   }
   
+  .modal-title {
+    text-align: center;
+  }
+  
   .nav {
     display: flex;
     display: -ms-flexbox;

--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/alertUtils.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/alertUtils.js
@@ -21,9 +21,11 @@ var alertUtils = (function() {
 				messageFrame("display", {action: action, config:config}).then(function(response) {
 					// Handle button choice
 					if (response.alertId) {
-						showAlertDetails(response.alertId);
+						let backFunction = function() {showAlerts(title, target, alertRisk)};
+						showAlertDetails(response.alertId, backFunction);
 					}
-				});
+				})
+				.catch(errorHandler);
 			})
 		.catch(errorHandler);
 	}
@@ -63,16 +65,18 @@ var alertUtils = (function() {
 				messageFrame("display", {action: action, config:config}).then(function(response) {
 					// Handle button choice
 					if (response.alertId) {
-						showAlertDetails(response.alertId);
+						let backFunction = function() {showPageAlerts(title, target, alertRisk)};
+						showAlertDetails(response.alertId, backFunction);
 					}
-				});
+				})
+				.catch(errorHandler);
 			})
 		.catch(errorHandler);
 	}
 
-	function showAlertDetails(id) {
+	function showAlertDetails(id, backFunction) { 
 		log (LOG_DEBUG, 'showAlertDetails', '' + id);
-		// get the alert details given the id
+
 		fetch("<<ZAP_HUD_API>>/core/view/alert/?id=" + id)
 			.then(function(response) {
 
@@ -83,7 +87,13 @@ var alertUtils = (function() {
 						config.title = json.alert.alert;
 						config.details = json.alert;
 
-						messageFrame("display", {action: "showAlertDetails", config: config});
+						messageFrame("display", {action: "showAlertDetails", config: config})
+							.then(function(response) {
+								if (response.back) {
+									backFunction();
+								}
+							})
+							.catch(errorHandler);
 					})
 					.catch(errorHandler);
 			})


### PR DESCRIPTION
creates a new modal with a back button to go to a previous modal. Applied to the alerts details so that you can navigate back to the alerts list modal.

Also adds the spectre icon css and centers the modal titles.