### PR TITLE
Use the new ZAP setCanGetFocus method

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -23,6 +23,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -189,6 +190,7 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
 	    this.hudEnabled = getHudParam().isEnabled();
 	    if (View.isInitialised()) {
 	        this.getHudButton().setSelected(hudEnabled);
+	        setZapCanGetFocus(! this.hudEnabled);
 	    }
 	    if (getHudParam().isDevelopmentMode()) {
             ZAP.getEventBus().publishSyncEvent(
@@ -200,6 +202,21 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
     protected boolean isHudEnabled() {
         return hudEnabled;
     }
+
+    /**
+     * Tell ZAP if it can grab the focus or not - should only be called if the 
+     * View has been initialised.
+     * @param canGetFocus
+     */
+    private void setZapCanGetFocus(boolean canGetFocus) {
+        // Post 2.7.0 so for now try to access via reflection
+        try {
+            Method m = View.class.getMethod("setCanGetFocus", boolean.class);
+            m.invoke(View.getSingleton(), canGetFocus);
+        } catch (Exception e) {
+            log.debug(e.getMessage(), e);
+        }
+   }
 
 	private void addHudScripts() {
 		this.baseDirectory = this.getHudParam().getBaseDirectory();
@@ -271,6 +288,7 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
 				public void actionPerformed(ActionEvent e) {
 					hudEnabled = hudButton.isSelected();
 					getHudParam().setEnabled(hudEnabled);
+					setZapCanGetFocus(! hudEnabled);
 				}});
     	}
     	return hudButton;


### PR DESCRIPTION
Uses reflection to see if its present, as I've only just implement that
;)
This will prevent the ZAP desktop from grabbing focus when the HUD is
turned on.