### PR TITLE
Implement resend in browser

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -90,6 +91,9 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
 	private static final int PROXY_LISTENER_ORDER = ProxyListenerLog.PROXY_LISTENER_ORDER + 1000;
 	
 	private static final List<Class<? extends Extension>> DEPENDENCIES;
+
+	private static final String REPLACE_REQUEST_PARAM = "zapHudReplaceReq=";
+	private Map<String, HttpMessage> recordedRequests = new HashMap<String, HttpMessage>();
 
 	static {
 	    List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
@@ -320,7 +324,22 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
 
 	@Override
 	public boolean onHttpRequestSend(HttpMessage msg) {
-		// Do nothing
+		// Check for a replaced request
+        try {
+            if (this.recordedRequests.size() > 0) {
+                String url = msg.getRequestHeader().getURI().toString();
+                HttpMessage replacedMsg = this.recordedRequests.remove(url);
+                if (replacedMsg != null) {
+                    msg.setRequestHeader(replacedMsg.getRequestHeader());
+                    msg.setRequestBody(replacedMsg.getRequestBody());
+                    log.debug("Replaced full message " + msg.getRequestHeader().getMethod());
+                } else {
+                    log.warn("Failed to find request with url " + url);
+                }
+            }
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
 		return true;
 	}
 	
@@ -374,6 +393,34 @@ public class ExtensionHUD extends ExtensionAdaptor implements ProxyListener, Scr
 		}
 		return true;
 	}
+	
+    protected String setRecordedRequest(HttpMessage request) {
+        /*
+         * The HUD UI calls the API endpoint that calls this function and then
+         * immediately calls the URL this function returns, which removes the
+         * recorded request. If that ever changes then there might be a requirement
+         * to delete any requests that have not been consumed.
+         */
+        String key = UUID.randomUUID().toString();
+        String url = request.getRequestHeader().getURI().toString();
+        StringBuilder sb = new StringBuilder();
+        if (url.indexOf(REPLACE_REQUEST_PARAM) > 0) {
+            sb.append(url.substring(0, url.indexOf(REPLACE_REQUEST_PARAM)));
+        } else {
+            sb.append(url);
+            if (url.contains("?")) {
+                sb.append('&');
+            } else {
+                sb.append('?');
+            }
+        }
+        sb.append(REPLACE_REQUEST_PARAM);
+        sb.append(key);
+        String reqUrl = sb.toString();
+        
+        this.recordedRequests.put(reqUrl, request);
+        return reqUrl;
+    }
 
     /** @return index of pattern in s or -1, if not found */
 	public static int regexEndOf(Pattern pattern, String s) {

--- a/src/org/zaproxy/zap/extension/hud/files/hud/display.css
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/display.css
@@ -7,3 +7,7 @@ body {
     padding-left: 1em;
     text-indent: -1em;
 }
+
+span.errorMessages {
+    color:red;
+}

--- a/src/org/zaproxy/zap/extension/hud/files/hud/display.html
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/display.html
@@ -216,8 +216,9 @@
         <template id="history-message-modal-template">
             <http-message-modal ref="messageModal" :title="title" :show="show" @close="close" :request="request" :response="response" :is-response-disabled="isResponseDisabled" :active-tab="activeTab">
                 <div slot="footer">
+                	<div><span class="errorMessages">{{errors}}</span></div>
                     <button class="btn btn-primary" @click="replay">Replay in Console</button>
-                    <button class="btn disabled" @click="replayInBrowser">Replay in Browser</button>
+                    <button class="btn" @click="replayInBrowser">Replay in Browser</button>
                 </div>
             </http-message-modal>
         </template>

--- a/src/org/zaproxy/zap/extension/hud/files/hud/display.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/display.js
@@ -359,7 +359,7 @@ Vue.component('break-message-modal', {
 
 Vue.component('history-message-modal', {
 	template: '#history-message-modal-template',
-	props: ['show', 'title'],
+	props: ['show', 'title', 'errors'],
 	methods: {
 		close: function() {
 			this.$emit('close');
@@ -371,7 +371,20 @@ Vue.component('history-message-modal', {
 			this.$emit('close');
 		},
 		replayInBrowser: function() {
-			console.log('this functionality isn\'t supported yet');
+			let dialog = this;
+			let message = this.request;
+			fetch("<<ZAP_HUD_API>>/hud/action/recordRequest/?header=" + encodeURIComponent(message.header) + "&body=" + encodeURIComponent(message.body))
+			.then(function(response) {
+				return response.json();
+			})
+			.then(function(json) {
+				if (json.requestUrl) {
+					window.top.location.href = json.requestUrl;
+				} else {
+					dialog.errors = "Invalid HTML header";
+				}
+			})
+			.catch(errorHandler)
 		}
 	},
 	data() {
@@ -380,7 +393,8 @@ Vue.component('history-message-modal', {
 			request: {},
 			response: {},
 			isResponseDisabled: false,
-			activeTab: "Request"
+			activeTab: 'Request',
+			errors: ''
 		}
 	},
 	created() {

--- a/src/org/zaproxy/zap/extension/hud/files/hud/target/inject.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/target/inject.js
@@ -321,6 +321,12 @@
 			'<iframe id="growler-alerts" src="<<ZAP_HUD_FILES>>?name=growlerAlerts.html" style="position: fixed; right: 0px; bottom: 0px; width: 500px; height: 0px;border: 0px none; z-index: 2147483647;"></iframe>';
 		document.body.appendChild(template.content);
 		document.body.style.marginBottom = "50px";
+		
+		let zapReplaceOffset = window.location.href.indexOf('zapHudReplaceReq=');
+		if (zapReplaceOffset > 0) {
+			// Hide the zapHudReplaceReq injected when resending a message in the browser
+			history.pushState({},document.title,window.location.href.substring(0, zapReplaceOffset-1));
+		}
 	}
 	
 	return {


### PR DESCRIPTION
This does allow you to resend GETs and POSTS and change any of the headers.
It also detects and warns of fatal errors in the HTML header, which the Resend in Console option doesnt handle ;)
Its not perfect - it adds a new url param to all requests it sends - these are stripped off in ZAP but I would like to prevent them from appearing in ZAP and the HUD. I think that should be possible, but I dont think its a blocker to reviewing this PR.