### PR TITLE
active scan label won't tweak out when running the attack tool

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/activeScan.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/activeScan.js
@@ -208,13 +208,19 @@ var ActiveScan = (function() {
 	self.addEventListener("org.zaproxy.zap.extension.ascan.ActiveScanEventPublisher", function(event) {
 		var eventType = event.detail['event.type'];
 		log (LOG_DEBUG, 'ActiveScanEventPublisher eventListener', 'Received ' + eventType + ' event');
-		if (eventType === 'scan.started') {
-			updateProgress("0%");
-		} else if (eventType === 'scan.progress') {
-			updateProgress(event.detail['scanProgress'] + '%');
-		} else  if (eventType === 'scan.stopped' || eventType === 'scan.completed') {
-			activeScanStopped();
-		}
+		checkIsRunning()
+			.then(function(isRunning) {
+				if (isRunning) {
+					if (eventType === 'scan.started') {
+						updateProgress("0%");
+					} else if (eventType === 'scan.progress') {
+						updateProgress(event.detail['scanProgress'] + '%');
+					} else  if (eventType === 'scan.stopped' || eventType === 'scan.completed') {
+						activeScanStopped();
+					}
+				}
+			})
+			.catch(errorHandler);
 	});
 
 	return {


### PR DESCRIPTION
The attack tool returns the same events from zap that the active scan returns, so the active scan tool was updating its progress when the attack tool was running. Just added a check to make sure the active scan is running before updating its status. 

There's still some undefined behaviour when using the Attack tool and Active Scan tools together, but tbh I'm not super familiar with these features in ZAP anyway and we can worry about that later.