### PR TITLE
Only show one flag per alert

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/commonAlerts.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/commonAlerts.js
@@ -111,9 +111,11 @@ var CommonAlerts = (function() {
 							for (var risk in RISKS) {
 								var alertRisk = RISKS[risk];
 								for (var alertName in pageAlerts[alertRisk]) {
+									let reportedParams = new Set();
 									for (var i = 0; i < pageAlerts[alertRisk][alertName].length; i++) {
 										var alert = pageAlerts[alertRisk][alertName][i];
-										if (alert.param.length > 0) {
+										if (alert.param.length > 0 && ! reportedParams.has(alert.param)) {
+											reportedParams.add(alert.param);
 											messageFrame("management", {
 												action: "commonAlerts.alert",
 												name: alert.name,


### PR DESCRIPTION
To test: spider bodgeit and then run the ascan with just (or at least)
integer overflow.
Then use the HUD - when you add something to the basket a load of alert
flags for integer overflows will be shown.
With this fix just one flag per vuln per field will be shown