### PR TITLE
Fix Replay in Console for POSTs

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/tools/history.js
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/tools/history.js
@@ -105,7 +105,7 @@ var History = (function() {
 		let req = header;
 
 		if (body) {
-			req = req + "\n\n" + encodeURIComponent(body)
+			req = req + "\r\n\r\n" + body
 		}
 
 		let params = "request=" + encodeURIComponent(req)


### PR DESCRIPTION
If you try to replay a POST message in the console then it fails.
This can be reproduced via the bodgeit 'Contact Us' form.
It was also double encoding the body which meant that that the requests werent doing the right things either.