### PR TITLE
Fix "details.reference is undefined" error

### DIFF
--- a/src/org/zaproxy/zap/extension/hud/files/hud/display.html
+++ b/src/org/zaproxy/zap/extension/hud/files/hud/display.html
@@ -206,10 +206,12 @@
                             </tr>
                             <tr>
                                 <td> Reference</td>
-                                <td>
+                                <td v-if="details['reference']" >
 	                                <li v-for="link in details['reference'].split('\n')">
 	                                	<a :href="link" target="_top">{{ link }}</a>
 	                                </li>
+                                </td>
+                                <td v-else >
                                 </td>
                             </tr>
                         </tbody>


### PR DESCRIPTION
Was happening when loading any page as per https://github.com/psiinon/zap-hud/pull/182#issuecomment-420587596