### PR TITLE
Add Java 11 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 jdk:
   - oraclejdk8
-  - openjdk8
+  - openjdk11
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Change .travis.yml to run the build with Java 11, instead of just with
Java 8.