### PR TITLE
Normalise format of Java code and license header

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import org.zaproxy.gradle.tasks.UpdateManifestFile
 plugins {
     `java-library`
     id("zap-add-on")
+    id("com.diffplug.gradle.spotless") version "3.15.0"
 }
 
 apply(from = "$rootDir/gradle/compile.gradle.kts")
@@ -64,6 +65,13 @@ tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }
 
+spotless {
+    java {
+        licenseHeaderFile("gradle/spotless/license.java")
+
+        googleJavaFormat().aosp()
+    }
+}
 
 tasks {
     register<Exec>("npmLintStagedHud") {

--- a/src/main/java/org/zaproxy/zap/extension/hud/HtmlEditor.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HtmlEditor.java
@@ -20,17 +20,14 @@
 package org.zaproxy.zap.extension.hud;
 
 import java.util.List;
-
-import org.parosproxy.paros.network.HttpMessage;
-
 import net.htmlparser.jericho.OutputDocument;
 import net.htmlparser.jericho.Source;
 import net.htmlparser.jericho.StartTag;
-/**
- * A class for injecting content into HTML responses
- */
+import org.parosproxy.paros.network.HttpMessage;
+
+/** A class for injecting content into HTML responses */
 public class HtmlEditor {
-    
+
     private HttpMessage msg;
     private Source source;
     private OutputDocument outputDocument;
@@ -49,17 +46,16 @@ public class HtmlEditor {
             this.outputDocument.insert(bodyTags.get(0).getEnd(), inject);
             this.changed = true;
         }
-
     }
-    
+
     public void rewriteHttpMessage() {
         if (this.changed) {
             msg.setResponseBody(this.outputDocument.toString());
             msg.getResponseHeader().setContentLength(this.msg.getResponseBody().length());
         }
     }
-    
-    public boolean isChanged () {
+
+    public boolean isChanged() {
         return this.changed;
     }
 }

--- a/src/main/java/org/zaproxy/zap/extension/hud/HttpUpgradeProxyListener.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HttpUpgradeProxyListener.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.hud;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
@@ -31,7 +30,6 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.eventBus.Event;
-
 
 public class HttpUpgradeProxyListener implements OverrideMessageProxyListener {
 
@@ -51,16 +49,21 @@ public class HttpUpgradeProxyListener implements OverrideMessageProxyListener {
     @Override
     public boolean onHttpRequestSend(HttpMessage msg) {
         if (this.extHud.isHudEnabled()) {
-            if (this.extHud.getHudParam().isInScopeOnly() && ! msg.isInScope()) {
+            if (this.extHud.getHudParam().isInScopeOnly() && !msg.isInScope()) {
                 return false;
             }
             try {
-                if (! msg.getRequestHeader().isSecure()) {
+                if (!msg.getRequestHeader().isSecure()) {
                     // 302 to the https version..
                     this.extHud.addUpgradedHttpsDomain(msg.getRequestHeader().getURI());
                     msg.setResponseHeader(
-                            HudAPI.getAllowFramingResponseHeader("302 OK", "text/html; charset=UTF-8", 0, false));
-                    String url = msg.getRequestHeader().getURI().toString().replaceFirst("(?i)http://", "https://");
+                            HudAPI.getAllowFramingResponseHeader(
+                                    "302 OK", "text/html; charset=UTF-8", 0, false));
+                    String url =
+                            msg.getRequestHeader()
+                                    .getURI()
+                                    .toString()
+                                    .replaceFirst("(?i)http://", "https://");
                     msg.getResponseHeader().addHeader(HttpHeader.LOCATION, url);
                     // Don't strictly need the body
                     msg.setResponseBody("<html><body>Redirecting to " + url + "</body></html>");
@@ -85,21 +88,28 @@ public class HttpUpgradeProxyListener implements OverrideMessageProxyListener {
         if (this.extHud.isHudEnabled()) {
             try {
                 URI url = msg.getRequestHeader().getURI();
-                if ((msg.getResponseHeader().getStatusCode() == 301 || msg.getResponseHeader().getStatusCode() == 302) &&
-                        this.extHud.isUpgradedHttpsDomain(url)) {
+                if ((msg.getResponseHeader().getStatusCode() == 301
+                                || msg.getResponseHeader().getStatusCode() == 302)
+                        && this.extHud.isUpgradedHttpsDomain(url)) {
                     String loc = msg.getResponseHeader().getHeader(HttpResponseHeader.LOCATION);
                     if (loc != null && loc.toLowerCase().startsWith("https")) {
-                        // We've upgraded it, but its upgrading itself anyway - let it do that so we dont get into a browser loop
+                        // We've upgraded it, but its upgrading itself anyway - let it do that so we
+                        // dont get into a browser loop
                         LOG.debug("onHttpResponseReceived not upgrading " + url);
                         this.extHud.removeUpgradedHttpsDomain(url);
                         // Advise that we're no longer upgrading this domain to https
                         Map<String, String> map = new HashMap<String, String>();
-                        map.put(HudEventPublisher.FIELD_DOMAIN, url.getHost() + ":" + url.getPort());
-                        ZAP.getEventBus().publishSyncEvent(
-                                HudEventPublisher.getPublisher(),
-                                new Event(HudEventPublisher.getPublisher(), 
-                                        HudEventPublisher.EVENT_DOMAIN_REDIRECTED_TO_HTTPS,
-                                        null, map ));
+                        map.put(
+                                HudEventPublisher.FIELD_DOMAIN,
+                                url.getHost() + ":" + url.getPort());
+                        ZAP.getEventBus()
+                                .publishSyncEvent(
+                                        HudEventPublisher.getPublisher(),
+                                        new Event(
+                                                HudEventPublisher.getPublisher(),
+                                                HudEventPublisher.EVENT_DOMAIN_REDIRECTED_TO_HTTPS,
+                                                null,
+                                                map));
                     }
                 }
             } catch (URIException e) {
@@ -108,5 +118,4 @@ public class HttpUpgradeProxyListener implements OverrideMessageProxyListener {
         }
         return false;
     }
-
 }

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudApiProxy.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudApiProxy.java
@@ -19,30 +19,25 @@
  */
 package org.zaproxy.zap.extension.hud;
 
+import net.sf.json.JSONObject;
 import org.apache.log4j.Logger;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
-import org.parosproxy.paros.network.HttpHeader;
 import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.api.API.RequestType;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.api.ApiResponse;
 
-import net.sf.json.JSONObject;
-
-/**
- * Used to allow content on the HUD domain to make API calls without using the API key.
- *
- */
+/** Used to allow content on the HUD domain to make API calls without using the API key. */
 public class HudApiProxy extends ApiImplementor {
 
     private static final String PREFIX = "hudapi";
 
     private static final Logger LOG = Logger.getLogger(HudApiProxy.class);
 
-    public HudApiProxy() {
-    }
+    public HudApiProxy() {}
 
     @Override
     public String getPrefix() {
@@ -58,7 +53,8 @@ public class HudApiProxy extends ApiImplementor {
 
             String[] elements = url.split("/");
 
-            // format is url is https://zap/zapCallBackUrl/randomstring/hud/view/hudData/?url=http://localhost:8080/bodgeit/
+            // format is url is
+            // https://zap/zapCallBackUrl/randomstring/hud/view/hudData/?url=http://localhost:8080/bodgeit/
             // 0 1 2 3 4 5 6 7 8
 
             if (elements.length < 8) {
@@ -77,12 +73,14 @@ public class HudApiProxy extends ApiImplementor {
 
             if (msg.getRequestHeader().getMethod().equalsIgnoreCase(HttpRequestHeader.GET)) {
                 params = API.getParams(msg.getRequestHeader().getURI().getEscapedQuery());
-            }
-            else if (msg.getRequestHeader().getMethod().equalsIgnoreCase(HttpRequestHeader.POST)) {
-                String contentTypeHeader = msg.getRequestHeader().getHeader(HttpHeader.CONTENT_TYPE);
+            } else if (msg.getRequestHeader()
+                    .getMethod()
+                    .equalsIgnoreCase(HttpRequestHeader.POST)) {
+                String contentTypeHeader =
+                        msg.getRequestHeader().getHeader(HttpHeader.CONTENT_TYPE);
 
                 if (contentTypeHeader != null
-                    && contentTypeHeader.equals(HttpHeader.FORM_URLENCODED_CONTENT_TYPE)) {
+                        && contentTypeHeader.equals(HttpHeader.FORM_URLENCODED_CONTENT_TYPE)) {
                     params = API.getParams(msg.getRequestBody().toString());
                 } else {
                     throw new ApiException(ApiException.Type.CONTENT_TYPE_NOT_SUPPORTED);
@@ -96,30 +94,31 @@ public class HudApiProxy extends ApiImplementor {
                 throw new ApiException(ApiException.Type.BAD_TYPE, elements[7]);
             }
             switch (reqType) {
-            case action:
-                response = impl.handleApiAction(elements[8], params);
-                break;
-            case view:
-                response = impl.handleApiView(elements[8], params);
-                break;
-            case other:
-                // Not currently needed
-                throw new ApiException(ApiException.Type.BAD_TYPE, reqType.name());
-            case pconn:
-                // Not currently supported - we want it, but it will require a load more work :/
-                throw new ApiException(ApiException.Type.BAD_TYPE, reqType.name());
-            default:
-                throw new ApiException(ApiException.Type.BAD_TYPE, reqType.name());
+                case action:
+                    response = impl.handleApiAction(elements[8], params);
+                    break;
+                case view:
+                    response = impl.handleApiView(elements[8], params);
+                    break;
+                case other:
+                    // Not currently needed
+                    throw new ApiException(ApiException.Type.BAD_TYPE, reqType.name());
+                case pconn:
+                    // Not currently supported - we want it, but it will require a load more work :/
+                    throw new ApiException(ApiException.Type.BAD_TYPE, reqType.name());
+                default:
+                    throw new ApiException(ApiException.Type.BAD_TYPE, reqType.name());
             }
-            msg.setResponseHeader(API.getDefaultResponseHeader("application/json; charset=UTF-8", 0, false));
+            msg.setResponseHeader(
+                    API.getDefaultResponseHeader("application/json; charset=UTF-8", 0, false));
             String body = response.toJSON().toString();
             msg.setResponseBody(body);
             msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
             return body;
         } catch (Exception e) {
             LOG.error("Failed at end " + e.getMessage(), e);
-            throw new ApiException(ApiException.Type.URL_NOT_FOUND, msg.getRequestHeader().getURI().toString());
+            throw new ApiException(
+                    ApiException.Type.URL_NOT_FOUND, msg.getRequestHeader().getURI().toString());
         }
     }
-
 }

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudBrowserTestThread.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudBrowserTestThread.java
@@ -26,7 +26,6 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -58,13 +57,12 @@ public class HudBrowserTestThread extends Thread {
     }
 
     private static ExtensionSelenium getExtSelenium() {
-        return Control.getSingleton().getExtensionLoader()
-                .getExtension(ExtensionSelenium.class);
+        return Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
     }
 
     @Override
     public void run() {
-        
+
         // Give it a bit of time to start up
         try {
             Thread.sleep(3000);
@@ -72,7 +70,7 @@ public class HudBrowserTestThread extends Thread {
             // Ignore
         }
         this.startTime = System.currentTimeMillis();
-        
+
         try (BufferedReader br = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
             String line;
             while ((line = br.readLine()) != null) {
@@ -80,9 +78,9 @@ public class HudBrowserTestThread extends Thread {
                     break;
                 }
                 // process the line.
-                if (! line.startsWith("#")) {
+                if (!line.startsWith("#")) {
                     // Not a comment
-                    if (! line.toLowerCase().startsWith("http")) {
+                    if (!line.toLowerCase().startsWith("http")) {
                         // The Alexa data typically doesnt include http(s)://
                         line = "http://" + line;
                     }
@@ -98,20 +96,23 @@ public class HudBrowserTestThread extends Thread {
     }
 
     @SuppressWarnings("cast")
-    private void testUrl(WebDriver wd, String url)  {
+    private void testUrl(WebDriver wd, String url) {
         try {
             wd.get(url);
 
-            WebElement panel = (new WebDriverWait(wd, 10))
-                    .until(ExpectedConditions.presenceOfElementLocated(By.id("left-panel")));
+            WebElement panel =
+                    (new WebDriverWait(wd, 10))
+                            .until(
+                                    ExpectedConditions.presenceOfElementLocated(
+                                            By.id("left-panel")));
 
             if (panel == null) {
-                this.fails.add(url + " : Failed to find left panel"); 
+                this.fails.add(url + " : Failed to find left panel");
             } else {
                 // Cast to make Eclipse compile without errors.
-                wd.switchTo().frame((WebElement)wd.findElement(By.id("left-panel")));
+                wd.switchTo().frame((WebElement) wd.findElement(By.id("left-panel")));
                 List<WebElement> buttons = null;
-                for (int i=0; i < 10; i++) {
+                for (int i = 0; i < 10; i++) {
                     buttons = wd.findElements(By.className("hud-button"));
                     if (buttons != null && buttons.size() == 8) {
                         this.passes.add(url);
@@ -120,29 +121,28 @@ public class HudBrowserTestThread extends Thread {
                     Thread.sleep(500);
                 }
                 if (buttons == null) {
-                    this.fails.add(url + " : Failed to find left panel buttons"); 
+                    this.fails.add(url + " : Failed to find left panel buttons");
                 } else {
-                    this.fails.add(url + " : Only found " + buttons.size() + " left panel buttons"); 
+                    this.fails.add(url + " : Only found " + buttons.size() + " left panel buttons");
                 }
             }
         } catch (Exception e) {
-            this.fails.add(url + " : Exception " + e.getMessage()); 
+            this.fails.add(url + " : Exception " + e.getMessage());
         }
-        
     }
 
     public List<String> getPasses() {
         return Collections.unmodifiableList(passes);
     }
-    
+
     public List<String> getFails() {
         return Collections.unmodifiableList(fails);
     }
-    
-    public int getProgress () {
+
+    public int getProgress() {
         return passes.size() + fails.size();
     }
-    
+
     public long getAverageLoadTimeInMSecs() {
         if (this.startTime == 0) {
             return 0;
@@ -152,7 +152,7 @@ public class HudBrowserTestThread extends Thread {
         }
         return (this.endTime - this.startTime) / this.getProgress();
     }
-    
+
     public void setStop(boolean stop) {
         this.stop = stop;
     }

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudEventPublisher.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudEventPublisher.java
@@ -1,23 +1,22 @@
 /*
  * Zed Attack Proxy (ZAP) and its related class files.
- * 
+ *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
- * 
+ *
  * Copyright 2018 The ZAP Development Team
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- *   
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
- * limitations under the License.  
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.zaproxy.zap.extension.hud;
 
 import org.zaproxy.zap.ZAP;
@@ -30,7 +29,7 @@ public class HudEventPublisher implements EventPublisher {
     public static final String EVENT_DEV_MODE_DISABLED = "devMode.disabled";
     public static final String EVENT_DOMAIN_UPGRADED_TO_HTTPS = "domain.upgraded";
     public static final String EVENT_DOMAIN_REDIRECTED_TO_HTTPS = "domain.redirected";
-    
+
     public static final String FIELD_DOMAIN = "domain";
 
     @Override
@@ -41,11 +40,15 @@ public class HudEventPublisher implements EventPublisher {
     public static synchronized HudEventPublisher getPublisher() {
         if (publisher == null) {
             publisher = new HudEventPublisher();
-            ZAP.getEventBus().registerPublisher(
-                    publisher,
-                    new String[] { EVENT_DEV_MODE_ENABLED, EVENT_DEV_MODE_DISABLED, 
-                            EVENT_DOMAIN_UPGRADED_TO_HTTPS, EVENT_DOMAIN_REDIRECTED_TO_HTTPS });
-
+            ZAP.getEventBus()
+                    .registerPublisher(
+                            publisher,
+                            new String[] {
+                                EVENT_DEV_MODE_ENABLED,
+                                EVENT_DEV_MODE_DISABLED,
+                                EVENT_DOMAIN_UPGRADED_TO_HTTPS,
+                                EVENT_DOMAIN_REDIRECTED_TO_HTTPS
+                            });
         }
         return publisher;
     }

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudFileProxy.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudFileProxy.java
@@ -25,10 +25,7 @@ import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 
-/**
- * Used to serve HUD files via callbacks. These files can be on either the HUD or target domains
- *
- */
+/** Used to serve HUD files via callbacks. These files can be on either the HUD or target domains */
 public class HudFileProxy extends ApiImplementor {
 
     private static final String PREFIX = "hudfiles";
@@ -54,7 +51,9 @@ public class HudFileProxy extends ApiImplementor {
             if (query != null) {
                 if (query.contains("..")) {
                     // Looks like an injection attack
-                    throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, msg.getRequestHeader().getURI().toString());
+                    throw new ApiException(
+                            ApiException.Type.ILLEGAL_PARAMETER,
+                            msg.getRequestHeader().getURI().toString());
                 }
                 if (query.indexOf("name=") > 0) {
                     String file = query.substring(query.indexOf("name=") + 5);
@@ -62,42 +61,54 @@ public class HudFileProxy extends ApiImplementor {
                         file = file.substring(0, file.indexOf("&"));
                     }
                     if (file.endsWith(".js")) {
-                        msg.setResponseHeader(API.getDefaultResponseHeader("application/javascript; charset=UTF-8", 0, false));
+                        msg.setResponseHeader(
+                                API.getDefaultResponseHeader(
+                                        "application/javascript; charset=UTF-8", 0, false));
                     } else if (file.endsWith(".html")) {
                         // Must allow framing or it wont work
                         msg.setResponseHeader(
-                                HudAPI.getAllowFramingResponseHeader("200 OK", "text/html; charset=UTF-8", 0, false));
+                                HudAPI.getAllowFramingResponseHeader(
+                                        "200 OK", "text/html; charset=UTF-8", 0, false));
                     } else if (file.endsWith(".css")) {
-                        msg.setResponseHeader(API.getDefaultResponseHeader("text/css; charset=UTF-8", 0, false));
+                        msg.setResponseHeader(
+                                API.getDefaultResponseHeader("text/css; charset=UTF-8", 0, false));
                     }
                     msg.setResponseBody(api.getFile(msg, file));
                     msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
-                    
+
                     if (msg.getRequestHeader().getURI().toString().startsWith(API.API_URL_S)) {
                         if (api.allowUnsafeEval()) {
-                            msg.getResponseHeader().setHeader("Content-Security-Policy", HudAPI.CSP_POLICY_UNSAFE_EVAL);
+                            msg.getResponseHeader()
+                                    .setHeader(
+                                            "Content-Security-Policy",
+                                            HudAPI.CSP_POLICY_UNSAFE_EVAL);
                         } else {
-                            msg.getResponseHeader().setHeader("Content-Security-Policy", HudAPI.CSP_POLICY);
+                            msg.getResponseHeader()
+                                    .setHeader("Content-Security-Policy", HudAPI.CSP_POLICY);
                         }
                     }
 
-                    
                     return msg.getResponseBody().toString();
                 } else if (query.indexOf("image=") > 0) {
                     String file = query.substring(query.indexOf("image=") + 6);
 
                     msg.setResponseBody(api.getImage(file));
-                    msg.setResponseHeader(API.getDefaultResponseHeader(
-                            getImageContentType(file), msg.getResponseBody().length(), true));
+                    msg.setResponseHeader(
+                            API.getDefaultResponseHeader(
+                                    getImageContentType(file),
+                                    msg.getResponseBody().length(),
+                                    true));
                     return msg.getResponseBody().toString();
                 }
             }
         } catch (Exception e) {
-            throw new ApiException(ApiException.Type.URL_NOT_FOUND, msg.getRequestHeader().getURI().toString());
+            throw new ApiException(
+                    ApiException.Type.URL_NOT_FOUND, msg.getRequestHeader().getURI().toString());
         }
-        throw new ApiException(ApiException.Type.URL_NOT_FOUND, msg.getRequestHeader().getURI().toString());
+        throw new ApiException(
+                ApiException.Type.URL_NOT_FOUND, msg.getRequestHeader().getURI().toString());
     }
-    
+
     private String getImageContentType(String name) {
         if (name.endsWith(".png")) {
             return "image/png";
@@ -108,5 +119,4 @@ public class HudFileProxy extends ApiImplementor {
             return "image";
         }
     }
-
 }

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudParam.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudParam.java
@@ -20,16 +20,13 @@
 package org.zaproxy.zap.extension.hud;
 
 import java.io.File;
-
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.common.VersionedAbstractParam;
 import org.zaproxy.zap.extension.api.ZapApiIgnore;
 
 public class HudParam extends VersionedAbstractParam {
 
-    /**
-     * The base configuration key for all HUD configurations.
-     */
+    /** The base configuration key for all HUD configurations. */
     private static final String PARAM_BASE_KEY = "hud";
 
     private static final String PARAM_ENABLED = PARAM_BASE_KEY + ".enabled";
@@ -42,27 +39,27 @@ public class HudParam extends VersionedAbstractParam {
     private static final String PARAM_TUTORIAL_HOST = PARAM_BASE_KEY + ".tutorialHost";
 
     /**
-     * The version of the configurations. Used to keep track of configurations changes between releases, if updates are needed.
-     * <p>
-     * It only needs to be updated for configurations changes (not releases of the add-on).
-     * </p>
+     * The version of the configurations. Used to keep track of configurations changes between
+     * releases, if updates are needed.
+     *
+     * <p>It only needs to be updated for configurations changes (not releases of the add-on).
      */
     private static final int PARAM_CURRENT_VERSION = 1;
 
     private String baseDirectory;
-    
+
     private boolean developmentMode;
-    
+
     private boolean allowUnsafeEval;
-    
+
     private boolean enabled;
-    
+
     private boolean inScopeOnly;
-    
+
     private boolean removeCSP;
-    
+
     private int tutorialPort;
-    
+
     private String tutorialHost;
 
     public String getBaseDirectory() {
@@ -74,57 +71,47 @@ public class HudParam extends VersionedAbstractParam {
         getConfig().setProperty(PARAM_BASE_DIRECTORY, baseDirectory);
     }
 
-    
     public boolean isDevelopmentMode() {
         return developmentMode;
     }
 
-    
     public void setDevelopmentMode(boolean developmentMode) {
         this.developmentMode = developmentMode;
         getConfig().setProperty(PARAM_DEV_MODE, developmentMode);
     }
 
-    
     public boolean isAllowUnsafeEval() {
         return allowUnsafeEval;
     }
 
-    
-    @ZapApiIgnore   // Feels too dangerous to allow this
+    @ZapApiIgnore // Feels too dangerous to allow this
     public void setAllowUnsafeEval(boolean allowUnsafeEval) {
         this.allowUnsafeEval = allowUnsafeEval;
         getConfig().setProperty(PARAM_ALLOW_UNSAFE_EVAL, allowUnsafeEval);
     }
 
-    
     public boolean isEnabled() {
         return enabled;
     }
 
-    
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
         getConfig().setProperty(PARAM_ENABLED, enabled);
     }
 
-    
     public boolean isInScopeOnly() {
         return inScopeOnly;
     }
 
-    
     public void setInScopeOnly(boolean inScopeOnly) {
         this.inScopeOnly = inScopeOnly;
         getConfig().setProperty(PARAM_IN_SCOPE_ONLY, inScopeOnly);
     }
 
-    
     public boolean isRemoveCSP() {
         return removeCSP;
     }
 
-    
     public void setRemoveCSP(boolean removeCSP) {
         this.removeCSP = removeCSP;
         getConfig().setProperty(PARAM_REMOVE_CSP, removeCSP);
@@ -142,8 +129,13 @@ public class HudParam extends VersionedAbstractParam {
 
     @Override
     protected void parseImpl() {
-        baseDirectory = getConfig()
-                .getString(PARAM_BASE_DIRECTORY, Constant.getZapHome() + File.separator + ExtensionHUD.DIRECTORY_NAME);
+        baseDirectory =
+                getConfig()
+                        .getString(
+                                PARAM_BASE_DIRECTORY,
+                                Constant.getZapHome()
+                                        + File.separator
+                                        + ExtensionHUD.DIRECTORY_NAME);
         enabled = getConfig().getBoolean(PARAM_ENABLED, false);
         developmentMode = getConfig().getBoolean(PARAM_DEV_MODE, false);
         allowUnsafeEval = getConfig().getBoolean(PARAM_ALLOW_UNSAFE_EVAL, false);
@@ -160,25 +152,24 @@ public class HudParam extends VersionedAbstractParam {
     }
 
     /**
-     * Returns the port the tutorial should run on.
-     * By default this will be 0, meaning that a random port will be used.
-     * This can be changed via a command line config value for unit tests
-     * where the port needs to be known in advance.
+     * Returns the port the tutorial should run on. By default this will be 0, meaning that a random
+     * port will be used. This can be changed via a command line config value for unit tests where
+     * the port needs to be known in advance.
+     *
      * @return
      */
     public int getTutorialPort() {
         return tutorialPort;
     }
-    
+
     /**
-     * Returns the host address the tutorial should run on.
-     * By default this will be 127.0.0.1.
-     * This can be changed via a command line config value for unit tests
-     * where the host needs to be another value.
+     * Returns the host address the tutorial should run on. By default this will be 127.0.0.1. This
+     * can be changed via a command line config value for unit tests where the host needs to be
+     * another value.
+     *
      * @return
      */
     public String getTutorialHost() {
         return tutorialHost;
     }
-    
 }

--- a/src/main/java/org/zaproxy/zap/extension/hud/OptionsHudPanel.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/OptionsHudPanel.java
@@ -25,7 +25,6 @@ import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
-
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
@@ -33,7 +32,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.border.EmptyBorder;
-
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
@@ -41,16 +39,12 @@ import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.view.LayoutHelper;
 
-/**
- * The HUD options panel.
- */
+/** The HUD options panel. */
 public class OptionsHudPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = -1L;
 
-    /**
-     * The name of the options panel.
-     */
+    /** The name of the options panel. */
     private static final String NAME = Constant.messages.getString("hud.optionspanel.name");
 
     private JTextField baseDirectory;
@@ -68,9 +62,11 @@ public class OptionsHudPanel extends AbstractParamPanel {
         JPanel panel = new JPanel(new GridBagLayout());
         panel.setBorder(new EmptyBorder(2, 2, 2, 2));
 
-        JButton directoryButton = new JButton(Constant.messages.getString("hud.optionspanel.button.baseDirectory"));
+        JButton directoryButton =
+                new JButton(Constant.messages.getString("hud.optionspanel.button.baseDirectory"));
         directoryButton.addActionListener(new FileChooserAction(getBaseDirectory()));
-        JLabel directoryLabel = new JLabel(Constant.messages.getString("hud.optionspanel.label.baseDirectory"));
+        JLabel directoryLabel =
+                new JLabel(Constant.messages.getString("hud.optionspanel.label.baseDirectory"));
         directoryLabel.setLabelFor(directoryButton);
         JPanel overridesPanel = new JPanel(new FlowLayout(FlowLayout.LEADING, 0, 0));
         overridesPanel.add(getBaseDirectory());
@@ -95,36 +91,43 @@ public class OptionsHudPanel extends AbstractParamPanel {
 
     private JCheckBox getInScopeOnly() {
         if (inScopeOnly == null) {
-            inScopeOnly = new JCheckBox(Constant.messages.getString("hud.optionspanel.label.inScopeOnly"));
+            inScopeOnly =
+                    new JCheckBox(
+                            Constant.messages.getString("hud.optionspanel.label.inScopeOnly"));
         }
         return inScopeOnly;
     }
 
     private JCheckBox getRemoveCsp() {
         if (removeCsp == null) {
-            removeCsp = new JCheckBox(Constant.messages.getString("hud.optionspanel.label.removeCsp"));
+            removeCsp =
+                    new JCheckBox(Constant.messages.getString("hud.optionspanel.label.removeCsp"));
         }
         return removeCsp;
     }
 
-    
     private JCheckBox getDevelopmentMode() {
         if (developmentMode == null) {
-            developmentMode = new JCheckBox(Constant.messages.getString("hud.optionspanel.label.developmentMode"));
-            developmentMode.addActionListener(new ActionListener() {
+            developmentMode =
+                    new JCheckBox(
+                            Constant.messages.getString("hud.optionspanel.label.developmentMode"));
+            developmentMode.addActionListener(
+                    new ActionListener() {
 
-                @Override
-                public void actionPerformed(ActionEvent event) {
-                    getAllowUnsafeEval().setEnabled(developmentMode.isSelected());
-                }});
+                        @Override
+                        public void actionPerformed(ActionEvent event) {
+                            getAllowUnsafeEval().setEnabled(developmentMode.isSelected());
+                        }
+                    });
         }
         return developmentMode;
     }
 
-    
     private JCheckBox getAllowUnsafeEval() {
         if (allowUnsafeEval == null) {
-            allowUnsafeEval = new JCheckBox(Constant.messages.getString("hud.optionspanel.label.allowUnsafeEval"));
+            allowUnsafeEval =
+                    new JCheckBox(
+                            Constant.messages.getString("hud.optionspanel.label.allowUnsafeEval"));
         }
         return allowUnsafeEval;
     }
@@ -148,7 +151,8 @@ public class OptionsHudPanel extends AbstractParamPanel {
         if (filename != null && filename.length() > 0) {
             File file = new File(filename);
             if (!file.isDirectory() || !file.canRead()) {
-                throw new IllegalArgumentException(Constant.messages.getString("hud.optionspanel.warn.badBaseDir"));
+                throw new IllegalArgumentException(
+                        Constant.messages.getString("hud.optionspanel.warn.badBaseDir"));
             }
         }
     }
@@ -157,7 +161,7 @@ public class OptionsHudPanel extends AbstractParamPanel {
     public void saveParam(Object obj) throws Exception {
         final OptionsParam options = (OptionsParam) obj;
         final HudParam param = options.getParamSet(HudParam.class);
-        
+
         // Raise any relevant events before saving
         if (param.isDevelopmentMode() != getDevelopmentMode().isSelected()) {
             String event;
@@ -166,9 +170,10 @@ public class OptionsHudPanel extends AbstractParamPanel {
             } else {
                 event = HudEventPublisher.EVENT_DEV_MODE_DISABLED;
             }
-            ZAP.getEventBus().publishSyncEvent(
-                    HudEventPublisher.getPublisher(),
-                    new Event(HudEventPublisher.getPublisher(), event, null));
+            ZAP.getEventBus()
+                    .publishSyncEvent(
+                            HudEventPublisher.getPublisher(),
+                            new Event(HudEventPublisher.getPublisher(), event, null));
         }
 
         param.setBaseDirectory(getBaseDirectory().getText());
@@ -181,7 +186,7 @@ public class OptionsHudPanel extends AbstractParamPanel {
     @Override
     public String getHelpIndex() {
         // TODO  add help
-        //return "addon.hud.options";
+        // return "addon.hud.options";
         return null;
     }
 
@@ -200,7 +205,9 @@ public class OptionsHudPanel extends AbstractParamPanel {
             String path = textField.getText();
             if (path != null) {
                 File file = new File(path);
-                if (file.canRead() && file.isDirectory() && file.getName().equals(ExtensionHUD.DIRECTORY_NAME)) {
+                if (file.canRead()
+                        && file.isDirectory()
+                        && file.getName().equals(ExtensionHUD.DIRECTORY_NAME)) {
                     fileChooser.setSelectedFile(file);
                 }
             }

--- a/src/main/java/org/zaproxy/zap/extension/hud/tutorial/TutorialProxyServer.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/tutorial/TutorialProxyServer.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.file.Files;
-
 import org.apache.log4j.Logger;
 import org.openqa.selenium.WebDriver;
 import org.parosproxy.paros.Constant;
@@ -57,16 +56,14 @@ public class TutorialProxyServer extends ProxyServer {
         this("ZAP-HUD-Tutorial");
         this.extension = extension;
     }
-    
-    /**
-     * The server is started after initialisation so that the parameters
-     * will have been loaded.
-     */
+
+    /** The server is started after initialisation so that the parameters will have been loaded. */
     public void start() {
-        int port = this.startServer(
-                extension.getHudParam().getTutorialHost(),
-                extension.getHudParam().getTutorialPort(),
-                true);
+        int port =
+                this.startServer(
+                        extension.getHudParam().getTutorialHost(),
+                        extension.getHudParam().getTutorialPort(),
+                        true);
         LOG.debug("HUD Tutorial port is " + port);
         this.hostPort = "127.0.0.1:" + port;
     }
@@ -82,7 +79,8 @@ public class TutorialProxyServer extends ProxyServer {
     }
 
     private String getTextFile(String name) {
-        File f = new File(this.extension.getHudParam().getBaseDirectory() + "/../hudtutorial", name);
+        File f =
+                new File(this.extension.getHudParam().getBaseDirectory() + "/../hudtutorial", name);
         if (!f.exists()) {
             LOG.debug("No such tutorial file: " + f.getAbsolutePath());
             return null;
@@ -100,13 +98,15 @@ public class TutorialProxyServer extends ProxyServer {
         return getDefaultResponseHeader(STATUS_OK, contentType, contentLength);
     }
 
-    private static String getDefaultResponseHeader(String responseStatus, String contentType, int contentLength) {
+    private static String getDefaultResponseHeader(
+            String responseStatus, String contentType, int contentLength) {
         StringBuilder sb = new StringBuilder(250);
 
         sb.append("HTTP/1.1 ").append(responseStatus).append("\r\n");
         sb.append("Pragma: no-cache\r\n");
         sb.append("Cache-Control: no-cache, no-store, must-revalidate\r\n");
-        sb.append("Content-Security-Policy: default-src 'none'; script-src 'self'; connect-src 'self'; child-src 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self'\r\n");
+        sb.append(
+                "Content-Security-Policy: default-src 'none'; script-src 'self'; connect-src 'self'; child-src 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self'\r\n");
         sb.append("Access-Control-Allow-Methods: GET,POST,OPTIONS\r\n");
         sb.append("Access-Control-Allow-Headers: ZAP-Header\r\n");
         sb.append("X-Frame-Options: DENY\r\n");
@@ -138,11 +138,13 @@ public class TutorialProxyServer extends ProxyServer {
                     byte[] image = extension.getAPI().getImage(name);
                     if (image == null) {
                         msg.setResponseBody("<html><body><h1>404 Not found</h1><body></html>");
-                        msg.setResponseHeader(getDefaultResponseHeader(STATUS_NOT_FOUND, "text/html", 0));
+                        msg.setResponseHeader(
+                                getDefaultResponseHeader(STATUS_NOT_FOUND, "text/html", 0));
                     } else {
                         msg.setResponseBody(image);
-                        msg.setResponseHeader(API.getDefaultResponseHeader(
-                                "image/png", msg.getResponseBody().length(), true));
+                        msg.setResponseHeader(
+                                API.getDefaultResponseHeader(
+                                        "image/png", msg.getResponseBody().length(), true));
                     }
                 } else {
                     String localStr = Constant.getLocale().toString();
@@ -153,14 +155,17 @@ public class TutorialProxyServer extends ProxyServer {
                     if (body == null) {
                         LOG.debug("Failed to find tutorial file " + name);
                         msg.setResponseBody("<html><body><h1>404 Not found</h1><body></html>");
-                        msg.setResponseHeader(getDefaultResponseHeader(STATUS_NOT_FOUND, "text/html", 0));
+                        msg.setResponseHeader(
+                                getDefaultResponseHeader(STATUS_NOT_FOUND, "text/html", 0));
                     } else {
                         msg.setResponseBody(body);
                         String contentType = "text/html";
                         if (name.endsWith(".css")) {
                             contentType = "text/css";
                         }
-                        msg.setResponseHeader(getDefaultResponseHeader(contentType, msg.getResponseBody().length()));
+                        msg.setResponseHeader(
+                                getDefaultResponseHeader(
+                                        contentType, msg.getResponseBody().length()));
                     }
                 }
             } catch (HttpMalformedHeaderException e) {
@@ -174,16 +179,20 @@ public class TutorialProxyServer extends ProxyServer {
             LOG.debug("onHttpResponseReceived " + msg.getRequestHeader().getURI().toString());
             return false;
         }
-
     }
 
     private class TutorialProxyThread extends ProxyThread {
 
         TutorialProxyThread(ProxyServer server, Socket socket) {
             // TODO change initiator?
-            super(server, socket, new HttpSender(server.getConnectionParam(), true, HttpSender.MANUAL_REQUEST_INITIATOR));
+            super(
+                    server,
+                    socket,
+                    new HttpSender(
+                            server.getConnectionParam(),
+                            true,
+                            HttpSender.MANUAL_REQUEST_INITIATOR));
         }
-
     }
 
     public ZapMenuItem getFirefoxToolsMenuItem() {
@@ -193,16 +202,19 @@ public class TutorialProxyServer extends ProxyServer {
 
         if (firefoxToolsMenuItem == null) {
             firefoxToolsMenuItem = new ZapMenuItem("hud.menu.tutorial.firefox");
-            firefoxToolsMenuItem.addActionListener(new ActionListener() {
+            firefoxToolsMenuItem.addActionListener(
+                    new ActionListener() {
 
-                @Override
-                public void actionPerformed(ActionEvent arg0) {
-                    ExtensionSelenium extSel = Control.getSingleton().getExtensionLoader().getExtension(
-                            ExtensionSelenium.class);
-                    WebDriver wd = extSel.getProxiedBrowserByName("Firefox");
-                    wd.get("http://" + hostPort);
-                }
-            });
+                        @Override
+                        public void actionPerformed(ActionEvent arg0) {
+                            ExtensionSelenium extSel =
+                                    Control.getSingleton()
+                                            .getExtensionLoader()
+                                            .getExtension(ExtensionSelenium.class);
+                            WebDriver wd = extSel.getProxiedBrowserByName("Firefox");
+                            wd.get("http://" + hostPort);
+                        }
+                    });
         }
         return firefoxToolsMenuItem;
     }
@@ -214,18 +226,20 @@ public class TutorialProxyServer extends ProxyServer {
 
         if (chromeToolsMenuItem == null) {
             chromeToolsMenuItem = new ZapMenuItem("hud.menu.tutorial.chrome");
-            chromeToolsMenuItem.addActionListener(new ActionListener() {
+            chromeToolsMenuItem.addActionListener(
+                    new ActionListener() {
 
-                @Override
-                public void actionPerformed(ActionEvent arg0) {
-                    ExtensionSelenium extSel = Control.getSingleton().getExtensionLoader().getExtension(
-                            ExtensionSelenium.class);
-                    WebDriver wd = extSel.getProxiedBrowserByName("Chrome");
-                    wd.get("http://" + hostPort);
-                }
-            });
+                        @Override
+                        public void actionPerformed(ActionEvent arg0) {
+                            ExtensionSelenium extSel =
+                                    Control.getSingleton()
+                                            .getExtensionLoader()
+                                            .getExtension(ExtensionSelenium.class);
+                            WebDriver wd = extSel.getProxiedBrowserByName("Chrome");
+                            wd.get("http://" + hostPort);
+                        }
+                    });
         }
         return chromeToolsMenuItem;
     }
-
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/HtmlEditorUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/HtmlEditorUnitTest.java
@@ -25,55 +25,52 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 
-/**
- * Unit test for {@link HtmlEditor}.
- */
+/** Unit test for {@link HtmlEditor}. */
 public class HtmlEditorUnitTest {
 
     private static final String EOB_TOKEN = "EOB";
     private static final String INJECT_TOKEN = "INJECT";
-    
+
     @Test
     public void testNoBodyTag() {
         genericTestWithNoBodyTag("<head></head>");
     }
-    
+
     @Test
     public void testCommentedBody() {
         genericTestWithNoBodyTag("<head></head><!--<body></body>-->");
     }
-    
+
     @Test
     public void testSimpleHtml() {
-        genericTestWithBodyTag(
-                "<head></head><body>" + EOB_TOKEN + "</body>");
+        genericTestWithBodyTag("<head></head><body>" + EOB_TOKEN + "</body>");
     }
-    
+
     @Test
     public void testCommentedAndUncommentedBody() {
-        genericTestWithBodyTag(
-                "<head></head><!--<body></body>--><body>" + EOB_TOKEN + "</body>");
+        genericTestWithBodyTag("<head></head><!--<body></body>--><body>" + EOB_TOKEN + "</body>");
     }
-    
+
     @Test
     public void testTwitterStyleBody() {
         genericTestWithBodyTag(
                 "<head>"
-                + "</head>"
-                + " <body class=\"three-col logged-out static-logged-out-home-page\" \n" + 
-                "data-fouc-class-names=\"swift-loading\"\n" + 
-                " dir=\"ltr\">" + EOB_TOKEN + "\n" + 
-                "      <script id=\"swift_loading_indicator\" nonce=\"G5f1XC57dp7ig7dTGs9oxw==\">\n" + 
-                "        document.body.className=document.body.className+\" \"+document.body.getAttribute(\"data-fouc-class-names\");\n" + 
-                "      </script>\n");
+                        + "</head>"
+                        + " <body class=\"three-col logged-out static-logged-out-home-page\" \n"
+                        + "data-fouc-class-names=\"swift-loading\"\n"
+                        + " dir=\"ltr\">"
+                        + EOB_TOKEN
+                        + "\n"
+                        + "      <script id=\"swift_loading_indicator\" nonce=\"G5f1XC57dp7ig7dTGs9oxw==\">\n"
+                        + "        document.body.className=document.body.className+\" \"+document.body.getAttribute(\"data-fouc-class-names\");\n"
+                        + "      </script>\n");
     }
-    
+
     @Test
     public void testMultipleBodyTags() {
-        genericTestWithBodyTag(
-                "<head></head><body>" + EOB_TOKEN + "</body><body></body>");
+        genericTestWithBodyTag("<head></head><body>" + EOB_TOKEN + "</body><body></body>");
     }
-    
+
     private void genericTestWithBodyTag(String htmlBody) {
         // Given
         HttpMessage msg = new HttpMessage();

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/generic/LeftPanelUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/generic/LeftPanelUnitTest.java
@@ -23,15 +23,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
-
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 public class LeftPanelUnitTest {
 
-    public LeftPanelUnitTest() {
-    }
+    public LeftPanelUnitTest() {}
 
     public static void runAllTests(WebDriver wd) {
         testLeftPanelLoads(wd);
@@ -52,5 +50,4 @@ public class LeftPanelUnitTest {
         assertEquals(9, buttons.size());
         wd.switchTo().parentFrame();
     }
-
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/generic/RightPanelUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/generic/RightPanelUnitTest.java
@@ -23,15 +23,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
-
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 public class RightPanelUnitTest {
 
-    public RightPanelUnitTest() {
-    }
+    public RightPanelUnitTest() {}
 
     public static void runAllTests(WebDriver wd) {
         testRightPanelLoads(wd);
@@ -52,5 +50,4 @@ public class RightPanelUnitTest {
         assertEquals(9, buttons.size());
         wd.switchTo().parentFrame();
     }
-
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/specific/ExampleDotComChromeUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/specific/ExampleDotComChromeUnitTest.java
@@ -19,6 +19,8 @@
  */
 package org.zaproxy.zap.extension.hud.ui.specific;
 
+import io.github.bonigarcia.Options;
+import io.github.bonigarcia.SeleniumExtension;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,9 +31,6 @@ import org.openqa.selenium.remote.CapabilityType;
 import org.zaproxy.zap.extension.hud.ui.generic.LeftPanelUnitTest;
 import org.zaproxy.zap.extension.hud.ui.generic.RightPanelUnitTest;
 
-import io.github.bonigarcia.Options;
-import io.github.bonigarcia.SeleniumExtension;
-
 @Disabled
 @ExtendWith(SeleniumExtension.class)
 public class ExampleDotComChromeUnitTest {
@@ -39,17 +38,15 @@ public class ExampleDotComChromeUnitTest {
     static final String TARGET = "https://www.example.com";
     // TODO parameterise the host:port
     static final String PROXY = "localhost:8090";
-    
-    @Options
-    ChromeOptions chromeOptions = new ChromeOptions();
+
+    @Options ChromeOptions chromeOptions = new ChromeOptions();
+
     {
         Proxy proxy = new Proxy();
-        proxy.setHttpProxy(PROXY)
-            .setFtpProxy(PROXY)
-            .setSslProxy(PROXY);
+        proxy.setHttpProxy(PROXY).setFtpProxy(PROXY).setSslProxy(PROXY);
 
         chromeOptions.setCapability(CapabilityType.PROXY, proxy);
-        chromeOptions.setCapability("acceptInsecureCerts",true);
+        chromeOptions.setCapability("acceptInsecureCerts", true);
     }
 
     @Test

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/specific/ExampleDotComFirefoxUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/specific/ExampleDotComFirefoxUnitTest.java
@@ -19,6 +19,8 @@
  */
 package org.zaproxy.zap.extension.hud.ui.specific;
 
+import io.github.bonigarcia.Options;
+import io.github.bonigarcia.SeleniumExtension;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,9 +31,6 @@ import org.openqa.selenium.remote.CapabilityType;
 import org.zaproxy.zap.extension.hud.ui.generic.LeftPanelUnitTest;
 import org.zaproxy.zap.extension.hud.ui.generic.RightPanelUnitTest;
 
-import io.github.bonigarcia.Options;
-import io.github.bonigarcia.SeleniumExtension;
-
 @Disabled
 @ExtendWith(SeleniumExtension.class)
 public class ExampleDotComFirefoxUnitTest {
@@ -39,14 +38,12 @@ public class ExampleDotComFirefoxUnitTest {
     static final String TARGET = "https://www.example.com";
     // TODO parameterise the host:port
     static final String PROXY = "localhost:8090";
-    
-    @Options
-    FirefoxOptions firefoxOptions = new FirefoxOptions();
+
+    @Options FirefoxOptions firefoxOptions = new FirefoxOptions();
+
     {
         Proxy proxy = new Proxy();
-        proxy.setHttpProxy(PROXY)
-            .setFtpProxy(PROXY)
-            .setSslProxy(PROXY);
+        proxy.setHttpProxy(PROXY).setFtpProxy(PROXY).setSslProxy(PROXY);
 
         firefoxOptions.addPreference("network.captive-portal-service.enabled", false);
         firefoxOptions.addPreference("network.proxy.type", 1);
@@ -70,5 +67,4 @@ public class ExampleDotComFirefoxUnitTest {
         RightPanelUnitTest.runAllTests(driver);
         // TODO add more tests
     }
-
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/uimap/HUD.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/uimap/HUD.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.hud.ui.uimap;
 
 import java.util.List;
-
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -31,11 +30,11 @@ public class HUD {
 
     private WebDriver webdriver;
     private int timeoutInSecs = 10;
-    
+
     public HUD(WebDriver webdriver) {
         this.webdriver = webdriver;
     }
-    
+
     public static By LEFT_PANEL_BY_ID = By.id("left-panel");
     public static By RIGHT_PANEL_BY_ID = By.id("right-panel");
     public static By HUD_BUTTON_BY_CLASSNAME = By.className("hud-button");
@@ -61,5 +60,4 @@ public class HUD {
     public List<WebElement> getHudButtons() {
         return webdriver.findElements(HUD_BUTTON_BY_CLASSNAME);
     }
-
 }


### PR DESCRIPTION
Set up the Spotless plugin to check/enforce the format/indentation of
the whole Java source code (currently set to use Google Java Style
(AOSP)) and the license header.