### PR TITLE
Use the directory of the add-on when testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/.m2/repository/webdriver/
 
-script: ./gradlew --continue check zapDownload deployAddOnTestZap zapRunTests
+script: ./gradlew --continue check zapDownload zapRunTests

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ val testResultsDir = layout.buildDirectory.dir("reports/tests/test").get()
 val zapPort = 8999
 // Use a key just to make sure the HUD works with one
 val zapApiKey = "password123"
-val zapCmdlineOpts = "-dir " + testZapHome + " -config hud.enabled=true -config hud.devMode=true -config hud.unsafeEval=true -config hud.tutorialPort=9998 -config api.key=" + zapApiKey + " -daemon"
+val zapCmdlineOpts = "-dir " + testZapHome + " -config hud.enabled=true -config hud.devMode=true -config hud.unsafeEval=true -config hud.tutorialPort=9998 -config api.key=" + zapApiKey + " -daemon -config start.addonDirs=$buildDir/zap/"
 val zapSleepAfterStart = 10L
 
 zapAddOn {
@@ -140,27 +140,13 @@ tasks {
             }        
         }
     }
-    
-    register<Copy>("deployAddOnTestZapBroken") {
-        // This should be the right way to deploy the HUD to the test dir, but on travis is wipes the plugins dir :/
-        from(tasks.named("assembleZapAddOn"))
-        into(file("$testZapInstall/zap/plugin/"))
-    }
 
-    register<Exec>("deployAddOnTestZap") {
-        group = LifecycleBasePlugin.VERIFICATION_GROUP
-        description = "Copy HUD plugin via the cmdline, as the proper task seems to clear the plugins dir on travis."
-
-        mustRunAfter("zapDownload")
-
-        commandLine("cp", "build/zap/hud-$status-$version.zap", "$testZapInstall/zap/plugin/")
-    }
-    
     register("zapStart") {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
         description = "Starts ZAP for the unit tests"
         
-        mustRunAfter("deployAddOnTestZap")
+        mustRunAfter("zapDownload")
+        dependsOn("assembleZapAddOn")
     
         doLast {
             delete(testZapHome)


### PR DESCRIPTION
Change ZAP's test command line arguments to load the add-on from its
directory and change `zapStart` to depend on `assembleZapAddOn` to
ensure the tests always use the latest changes automatically.
Remove tasks no longer needed and adjust Travis CI build accordingly.