### PR TITLE
Conditional drop

### DIFF
--- a/src/main/zapHomeFiles/hud/display.html
+++ b/src/main/zapHomeFiles/hud/display.html
@@ -260,7 +260,7 @@
                 <div slot="footer">
                     <button class="btn btn-primary" @click="step"> {{ $t('message.break_step') }} </button>
                     <button class="btn btn-primary" @click="continueOn"> {{ $t('message.break_continue') }} </button>
-                    <button class="btn" @click="drop"> {{ $t('message.break_drop') }} </button>
+                    <button :class="{'btn': true, 'disabled': isDropDisabled}" @click="drop"> {{ $t('message.break_drop') }} </button>
                 </div>
             </http-message-modal>
         </template>

--- a/src/main/zapHomeFiles/hud/display.js
+++ b/src/main/zapHomeFiles/hud/display.js
@@ -325,6 +325,7 @@ Vue.component('break-message-modal', {
 			port: null,
 			request: {},
 			response: {},
+			isDropDisabled: false,
 			isResponseDisabled: false,
 			activeTab: I18n.t("common_request")
 		}
@@ -341,6 +342,21 @@ Vue.component('break-message-modal', {
 			
 			self.request.isReadonly = !data.isResponseDisabled;
 			self.response.isReadonly = data.isResponseDisabled;
+
+			// Only show the Drop option for things that dont look like a requests for a web page as this can break the HUD UI
+			if (data.isResponseDisabled) {
+				// Its a request
+				let headerLc = data.request.header.toLowerCase();
+				self.isDropDisabled = headerLc.match('accept:.*text\/html');
+				// Explicitly XHRs should be fine
+				if (headerLc.match('x-requested-with.*xmlhttprequest')) {
+					self.isDropDisabled = false;
+				}
+			} else {
+				// Its a response
+				let headerLc = data.response.header.toLowerCase();
+				self.isDropDisabled = headerLc.match('content-type:.*text\/html');
+			}
 
 			app.isBreakMessageModalShown = true;
 			app.BreakMessageModalTitle = data.title;


### PR DESCRIPTION
Fixes #131

Only display the break 'drop' option if we're sure its not a request for an HTML page.

Can use pages like https://www.w3schools.com/js/tryit.asp?filename=tryjs_ajax_first for actually dropping XHRs