### PR TITLE
Ignore libraries when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
       "git add"
     ]
   },
+  "xo": {
+    "ignores": [
+      "src/**/hud/libraries/**"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/psiinon/zap-hud.git"


### PR DESCRIPTION
Configure `xo` to ignore the libraries under the `hud` directory, it's
external code.