### PR TITLE
Prevent break hanging if window not accessible

### DIFF
--- a/src/main/zapHomeFiles/hud/tools/break.js
+++ b/src/main/zapHomeFiles/hud/tools/break.js
@@ -179,6 +179,17 @@ var Break = (function() {
 		config.request.method = parseRequestHeader(data.requestHeader).method;
 		config.request.header = data.requestHeader.trim();
 		config.request.body = data.requestBody;
+		
+		getWindowVisibilityState('display')
+			.then(state => {
+				if (state != 'visible') {
+					// The target window isn't ready to accept the break event so just step through it.
+					// Not ideal but most of these requests will be less interesting (css and JS)
+					log(LOG_DEBUG, 'break.showBreakDisplay', 'Target window not ready, stepping');
+					step();
+					return;
+				}
+			});
 
 		messageFrame("display", {action:"showBreakMessage", config:config})
 			.then(response => {

--- a/src/main/zapHomeFiles/hud/utils.js
+++ b/src/main/zapHomeFiles/hud/utils.js
@@ -497,6 +497,17 @@ function messageFrame(key, message) {
 }
 
 /*
+ * Returns the visibilityState of the specified iframe window
+ */
+function getWindowVisibilityState(key) {
+	return loadFrame(key)
+		.then(getWindowFromFrame)
+		.then(window => {
+			return window.visibilityState;
+		});
+}
+
+/*
  * Get the window object from a stored frame blob. Throws NoClientIdError if
  * the clientId doesn't exist.
  */


### PR DESCRIPTION
Fixes #245

Detects if the target window isnt ready and steps through the break
point.
Its not idea but I think its the best option right now.
I've still hit the problem once when stepping through a full load of
bbc.co.uk but its way better than before.