### PR TITLE
Return promise when adding domain to scope

### DIFF
--- a/src/main/zapHomeFiles/hud/tools/scope.js
+++ b/src/main/zapHomeFiles/hud/tools/scope.js
@@ -94,7 +94,7 @@ var Scope = (function() {
 	}
 
 	function addToScope(domain) {
-        loadTool(NAME)
+        return loadTool(NAME)
             .then(tool => {
                 if (! tool.hudContext) {
                     zapApiCall("/context/action/newContext/?contextName=" + HUD_CONTEXT)


### PR DESCRIPTION
Change scope tool to return the promise when adding the domain to scope,
it's required by the scan tools (e.g. spider, active scan) when adding
the domain to scope before starting the scan.