### PR TITLE
Add environments to XO

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     ]
   },
   "xo": {
+    "envs": [
+      "browser",
+      "serviceworker"
+    ],
     "ignores": [
       "src/**/hud/libraries/**"
     ]


### PR DESCRIPTION
Add `browser` and `serviceworker` to address some undefined variables.