### PR TITLE
Enable debug logging by default only in dev mode

### DIFF
--- a/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -174,8 +174,10 @@ public class HudAPI extends ApiImplementor {
     }
 
     public boolean allowUnsafeEval() {
-        return this.extension.getHudParam().isDevelopmentMode()
-                && this.extension.getHudParam().isAllowUnsafeEval();
+        /*
+         * TODO also require this.extension.getHudParam().isDevelopmentMode() once the HUD works with unsafe eval off.
+         */
+        return this.extension.getHudParam().isAllowUnsafeEval();
     }
 
     @Override
@@ -374,7 +376,14 @@ public class HudAPI extends ApiImplementor {
                                     "<<ZAP_LOCALE>>", Constant.messages.getLocal().toString());
 
                 } else if (file.equals("utils.js")) {
-                    contents = contents.replace("<<ZAP_HUD_API>>", this.hudApiUrl);
+                    contents =
+                            contents.replace("<<ZAP_HUD_API>>", this.hudApiUrl)
+                                    .replace(
+                                            "<<DEV_MODE>>",
+                                            Boolean.toString(
+                                                    this.extension
+                                                            .getHudParam()
+                                                            .isDevelopmentMode()));
                 } else if (file.equals("serviceworker.js")) {
                     contents = contents.replace("<<ZAP_HUD_WS>>", getWebSocketUrl());
                 } else if (file.equals("websockettest.js")) {

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudParam.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudParam.java
@@ -191,7 +191,8 @@ public class HudParam extends VersionedAbstractParam {
                                 Constant.getZapHome() + ExtensionHUD.DIRECTORY_NAME);
         enabledForDesktop = getConfig().getBoolean(PARAM_ENABLED_DESKTOP, true);
         enabledForDaemon = getConfig().getBoolean(PARAM_ENABLED_DAEMON, false);
-        developmentMode = getConfig().getBoolean(PARAM_DEV_MODE, true);
+        developmentMode = getConfig().getBoolean(PARAM_DEV_MODE, false);
+        // TODO default allowUnsafeEval to false once the HUD works without it set
         allowUnsafeEval = getConfig().getBoolean(PARAM_ALLOW_UNSAFE_EVAL, true);
         inScopeOnly = getConfig().getBoolean(PARAM_IN_SCOPE_ONLY, false);
         removeCSP = getConfig().getBoolean(PARAM_REMOVE_CSP, true);

--- a/src/main/java/org/zaproxy/zap/extension/hud/OptionsHudPanel.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/OptionsHudPanel.java
@@ -168,7 +168,8 @@ public class OptionsHudPanel extends AbstractParamPanel {
 
                         @Override
                         public void actionPerformed(ActionEvent event) {
-                            getAllowUnsafeEval().setEnabled(developmentMode.isSelected());
+                            // TODO uncomment once the HUD works without unsafe eeval
+                            // getAllowUnsafeEval().setEnabled(developmentMode.isSelected());
                         }
                     });
         }
@@ -198,7 +199,8 @@ public class OptionsHudPanel extends AbstractParamPanel {
         getSkipTutorialTasks().setSelected(param.isSkipTutorialTasks());
         getDevelopmentMode().setSelected(param.isDevelopmentMode());
         getAllowUnsafeEval().setSelected(param.isAllowUnsafeEval());
-        getAllowUnsafeEval().setEnabled(developmentMode.isSelected());
+        // TODO uncomment once the HUD works without unsafe eeval
+        // getAllowUnsafeEval().setEnabled(developmentMode.isSelected());
         getResetTutorialTasks().setEnabled(param.getTutorialTasksDone().size() > 0);
     }
 

--- a/src/main/zapHomeFiles/hud/utils.js
+++ b/src/main/zapHomeFiles/hud/utils.js
@@ -7,9 +7,9 @@
 // Injected strings
 var ZAP_HUD_FILES = '<<ZAP_HUD_FILES>>';
 var ZAP_HUD_API = '<<ZAP_HUD_API>>';
+var IS_DEV_MODE = '<<DEV_MODE>>' === 'true' ? true : false ;
 
 var IS_HUD_CONFIGURED = "isHudConfigured";
-var IS_DEBUG_ENABLED = false;
 var IS_FIRST_TIME = "isFirstTime";
 
 var LOG_OFF = 0;	// Just use for setting the level, nothing will be logged
@@ -20,9 +20,9 @@ var LOG_DEBUG = 4;	// Relatively fine grain events which can help debug problems
 var LOG_TRACE = 5;	// Very fine grain events, highest level
 var LOG_STRS = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'];
 
-var LOG_LEVEL = LOG_DEBUG;	// TODO change to INFO before release..
+var LOG_LEVEL = IS_DEV_MODE ? LOG_DEBUG : LOG_INFO;
 var LOG_TO_CONSOLE = true;
-var LOG_TO_ZAP = true;
+var LOG_TO_ZAP = IS_DEV_MODE;
 
 var CLIENT_LEFT = "left";
 var CLIENT_RIGHT = "right";
@@ -35,9 +35,12 @@ var BUTTON_LABEL = /BUTTON_LABEL/g;
 var IMAGE_NAME = /IMAGE_NAME/g;
 
 // default tools
-var DEFAULT_TOOLS_LEFT = ["scope", "break", "showEnable", "page-alerts-high", "page-alerts-medium", "page-alerts-low", "page-alerts-informational", "hudErrors"];
+var DEFAULT_TOOLS_LEFT = ["scope", "break", "showEnable", "page-alerts-high", "page-alerts-medium", "page-alerts-low", "page-alerts-informational"];
 var DEFAULT_TOOLS_RIGHT = ["site-tree", "spider", "active-scan", "attack", "site-alerts-high", "site-alerts-medium", "site-alerts-low", "site-alerts-informational"];
 
+if (IS_DEV_MODE) {
+	DEFAULT_TOOLS_LEFT.push("hudErrors");
+}
 
 class NoClientIdError extends Error {};
 


### PR DESCRIPTION
Also removed HUD error tool from the left hand panel. It can of course be readded.
Also you no longer will need dev mode turned on to use the HUD, so unsafeeval now works without requiring dev mode.

Part of #259

Note that this will in effect turn off the current hack which uses logging as a heartbeat.
I'll submit another PR to add a new API call for that, and maybe make it into a websocket request (suggested by @thc202 )