### PR TITLE
Include test stack trace when running in Travis CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 }
 
 apply(from = "$rootDir/gradle/compile.gradle.kts")
+apply(from = "$rootDir/gradle/travis-ci.gradle.kts")
 
 repositories {
     mavenLocal()
@@ -222,19 +223,6 @@ tasks {
         dependsOn("zapStop")
     }
 
-    register<Exec>("catFirefoxTestReport") {
-        group = LifecycleBasePlugin.VERIFICATION_GROUP
-        description = "Outputs the Firefox html unit test report to stdout."
-
-        commandLine("cat", "$testResultsDir/classes/org.zaproxy.zap.extension.hud.ui.specific.ExampleDotComFirefoxUnitTest.html")
-    }
-
-    register<Exec>("catZapLog") {
-        group = LifecycleBasePlugin.VERIFICATION_GROUP
-        description = "Outputs the zap.log file to stdout."
-
-        commandLine("cat", "$testZapHome/zap.log")
-    }
 }
 
 tasks.named<Test>("test") { 

--- a/gradle/travis-ci.gradle.kts
+++ b/gradle/travis-ci.gradle.kts
@@ -1,0 +1,13 @@
+// Build tweaks when running in Travis CI
+
+fun isEnvVarTrue(envvar: String) = System.getenv(envvar) == "true"
+
+if (isEnvVarTrue("TRAVIS") && isEnvVarTrue("CI")) {
+
+    tasks.withType(Test::class).configureEach {
+        testLogging {
+            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        }
+    }
+
+}


### PR DESCRIPTION
Use full format to output the stack trace when the tests fail, to make
it easier to know where it's failing.
Remove helper tasks `catZapLog` and `catFirefoxTestReport`, should no
longer be needed.