### PR TITLE
Specify the WebDriver versions to use in tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -244,3 +244,9 @@ tasks.named<Test>("test") {
     }  
 }
 
+tasks.withType(Test::class).configureEach {
+    systemProperties.putAll(mapOf(
+            "wdm.chromeDriverVersion" to "2.44",
+            "wdm.geckoDriverVersion" to "0.23.0",
+            "wdm.forceCache" to "true"))
+}


### PR DESCRIPTION
Specify the versions to avoid unnecessary requests to external servers,
that check the connection and the latest versions available.
This prevents the tests from failing because of the requests being
rejected (e.g. GitHub when checking for geckodriver).