### PR TITLE
Make ZAP tasks OS independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/.m2/repository/webdriver/
 
-script: ./gradlew --continue check zapDownload zapRunTests
+script: ./gradlew --continue check zapRunTests

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,8 @@
 import org.zaproxy.gradle.tasks.GenerateI18nJsFile
 import org.zaproxy.gradle.tasks.UpdateManifestFile
-import org.w3c.dom.Document
-import org.w3c.dom.Element
-import org.w3c.dom.Node
-import org.w3c.dom.NodeList
-import java.io.File
-import java.net.URL
-import java.util.Scanner
-import javax.xml.parsers.DocumentBuilderFactory
-import javax.xml.xpath.XPathConstants
-import javax.xml.xpath.XPathFactory
+import org.zaproxy.gradle.tasks.ZapDownloadWeekly
+import org.zaproxy.gradle.tasks.ZapStart
+import org.zaproxy.gradle.tasks.ZapShutdown
 
 plugins {
     `java-library`
@@ -31,14 +24,14 @@ val genHudFilesDir = layout.buildDirectory.dir("genHudFiles").get()
 val generatedI18nJsFileDir = genHudFilesDir.dir("i18nJs")
 val zapHome = layout.buildDirectory.dir("zapHome").get()
 val testZapHome = layout.buildDirectory.dir("testZapHome").get()
-val testZapInstall = layout.buildDirectory.dir("testZapInstall").get()
+val zapDownloadDir = layout.buildDirectory.dir("testZapInstall").get()
+val zapInstallDir = zapDownloadDir.dir("zap")
 val testResultsDir = layout.buildDirectory.dir("reports/tests/test").get()
 val zapPort = 8999
 // Use a key just to make sure the HUD works with one
 val zapApiKey = "password123"
-val hudDevArgs = "-config hud.enabledForDesktop=true -config hud.enabledForDaemon=true -config hud.devMode=true -config hud.unsafeEval=true"
-val zapCmdlineOpts = "-dir $testZapHome $hudDevArgs -config hud.tutorialPort=9998 -config hud.tutorialTestMode=true -config hud.showWelcomeScreen=false -config api.key=$zapApiKey -daemon -config start.addonDirs=$buildDir/zap/"
-val zapSleepAfterStart = 10L
+val hudDevArgs = listOf("-config", "hud.enabledForDesktop=true", "-config", "hud.enabledForDaemon=true", "-config", "hud.devMode=true", "-config", "hud.unsafeEval=true")
+val zapCmdlineOpts = listOf("-config", "hud.tutorialPort=9998", "-config", "hud.tutorialTestMode=true", "-config", "hud.showWelcomeScreen=false", "-daemon", "-config", "start.addonDirs=$buildDir/zap/") + hudDevArgs
 
 zapAddOn {
     addOnId.set("hud")
@@ -141,32 +134,23 @@ tasks {
         } 
     }
 
-    register("zapDownload") {
+    register<ZapDownloadWeekly>("zapDownload") {
         group = "Verification"
         description = "Downloads the latest ZAP weekly release for the unit tests"
-    
+
+        onlyIf { !zapInstallDir.asFile.exists() }
+
+        into.set(zapDownloadDir.asFile)
+        zapVersions.set("https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml")
+
         doLast {
-            mkdir(testZapInstall)
-            // Extract url from versions url
-            val zapvUrl = "https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml"
-            val xmlDoc: Document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(zapvUrl)
-            val xpFactory = XPathFactory.newInstance()
-            val xPath = xpFactory.newXPath()
-            val xpath = "/ZAP/core/daily/url"
-            val elementNodeList = xPath.evaluate(xpath, xmlDoc, XPathConstants.NODESET) as NodeList
-            val weeklyUrl = elementNodeList.item(0).getTextContent()
-             
-            // Download and extract file
-            val fileName = weeklyUrl.substring(weeklyUrl.lastIndexOf('/') + 1);
-            // fileName is of the form ZAP_WEEKLY_D-2018-10-16.zip
-            val day = fileName.substring(13, 23);
-            ant.withGroovyBuilder {
-                "get"("src" to weeklyUrl, "dest" to "$testZapInstall", "skipexisting" to "true")
-                  "unzip"("src" to "$testZapInstall/$fileName", "dest" to testZapInstall)
-                  // Rename the dir so we'll always know where it is
-                  "move"("file" to "$testZapInstall/ZAP_D-" + day, "tofile" to "$testZapInstall/zap")
-                  Runtime.getRuntime().exec("chmod +x " + "$testZapInstall/zap/zap.sh")
-            }        
+            copy {
+                from(zipTree(fileTree(zapDownloadDir.asFile).matching { "*.zip" }.singleFile)).eachFile {
+                    path = path.substring(relativePath.segments[0].length)
+                }
+                into(zapInstallDir)
+                includeEmptyDirs = false
+            }
         }
     }
 
@@ -178,47 +162,42 @@ tasks {
         into(zapHome)
     }
 
-    register("runZap") {
+    register<ZapStart>("runZap") {
         description = "Runs ZAP (weekly) with the HUD in dev mode."
 
-        if (!file("$testZapInstall/zap").exists()) {
-            dependsOn("zapDownload")
-        }
-        dependsOn("assembleZapAddOn", "copyHudClientFiles")
+        dependsOn("zapDownload", "assembleZapAddOn", "copyHudClientFiles")
 
-        doLast {
-            val args = "-dir $zapHome -dev -config start.checkForUpdates=false -config start.addonDirs=$buildDir/zap/ $hudDevArgs -config hud.dir=$zapHome/hud"
-            Runtime.getRuntime().exec("$testZapInstall/zap/zap.sh $args")
-        }
+        installDir.set(zapInstallDir.asFile)
+        homeDir.set(zapHome.asFile)
+
+        args.set(listOf("-dev", "-config", "start.checkForUpdates=false", "-config", "start.addonDirs=$buildDir/zap/", "-config", "hud.dir=$zapHome/hud") + hudDevArgs)
     }
 
-    register("zapStart") {
+    register<ZapStart>("zapStart") {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
         description = "Starts ZAP for the unit tests"
         
-        mustRunAfter("zapDownload")
-        dependsOn("assembleZapAddOn")
-    
-        doLast {
+        dependsOn("zapDownload", "assembleZapAddOn")
+
+        installDir.set(zapInstallDir.asFile)
+        homeDir.set(testZapHome.asFile)
+        port.set(zapPort)
+        apiKey.set(zapApiKey)
+        args.set(zapCmdlineOpts)
+
+        doFirst {
             delete(testZapHome)
-            Runtime.getRuntime().exec("pwd")
-            System.out.println("Starting ZAP")
-            Runtime.getRuntime().exec("$testZapInstall/zap/zap.sh -port " + zapPort + " " + zapCmdlineOpts)
-            Thread.sleep(zapSleepAfterStart * 1000)
-            System.out.println("Started ZAP")
         }
     }
     
-    register("zapStop") {
+    register<ZapShutdown>("zapStop") {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
         description = "Stops ZAP after the unit tests have been run"
         
+        port.set(zapPort)
+        apiKey.set(zapApiKey)
+
         shouldRunAfter("test")
-    
-        doLast {
-            System.out.println("Stopping ZAP")
-            Runtime.getRuntime().exec("curl http://localhost:" + zapPort + "/JSON/core/action/shutdown/?apikey=" + zapApiKey)
-        }
     }
     
     tasks.create("zapRunTests") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
     implementation("org.apache.commons:commons-lang3:3.8.1")
+    implementation("org.zaproxy:zap-clientapi:1.6.0")
 }
 
 java {

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapApiTask.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapApiTask.java
@@ -1,0 +1,76 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.zaproxy.clientapi.core.ClientApi;
+
+/** A task that accesses the ZAP API. */
+public class ZapApiTask extends DefaultTask {
+
+    private static final String DEFAULT_ADDRESS = "127.0.0.1";
+    private static final int DEFAULT_PORT = 8080;
+
+    private final Property<String> address;
+    private final Property<Integer> port;
+    private final Property<String> apiKey;
+
+    public ZapApiTask() {
+        ObjectFactory objects = getProject().getObjects();
+        address = objects.property(String.class);
+        address.set(DEFAULT_ADDRESS);
+        port = objects.property(Integer.class);
+        port.set(DEFAULT_PORT);
+        apiKey = objects.property(String.class);
+    }
+
+    @Input
+    public Property<String> getAddress() {
+        return address;
+    }
+
+    @Input
+    public Property<Integer> getPort() {
+        return port;
+    }
+
+    @Input
+    @Optional
+    public Property<String> getApiKey() {
+        return apiKey;
+    }
+
+    protected ClientApi createClient() {
+        validatePort(port.get());
+
+        return new ClientApi(address.get(), port.get(), apiKey.getOrNull());
+    }
+
+    private static void validatePort(int port) {
+        if (port <= 0 || port > 65535) {
+            throw new IllegalArgumentException(
+                    "The specified port is not valid, it should be > 0 and <= 65535.");
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapDownloadWeekly.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapDownloadWeekly.java
@@ -1,0 +1,97 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.tasks;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+/** A task that downloads a ZAP weekly release. */
+public class ZapDownloadWeekly extends DefaultTask {
+
+    private final Property<File> into;
+    private final Property<String> zapVersions;
+
+    public ZapDownloadWeekly() {
+        ObjectFactory objects = getProject().getObjects();
+        into = objects.property(File.class);
+        zapVersions = objects.property(String.class);
+    }
+
+    @Input
+    public Property<File> getInto() {
+        return into;
+    }
+
+    @Input
+    public Property<String> getZapVersions() {
+        return zapVersions;
+    }
+
+    @TaskAction
+    public void download() {
+        getProject().mkdir(into);
+
+        try {
+            Document xmlDoc =
+                    DocumentBuilderFactory.newInstance()
+                            .newDocumentBuilder()
+                            .parse(zapVersions.get());
+            NodeList elementNodeList =
+                    (NodeList)
+                            XPathFactory.newInstance()
+                                    .newXPath()
+                                    .evaluate(
+                                            "/ZAP/core/daily/url", xmlDoc, XPathConstants.NODESET);
+            String weeklyUrl = elementNodeList.item(0).getTextContent();
+
+            String fileName = weeklyUrl.substring(weeklyUrl.lastIndexOf('/') + 1);
+            try (InputStream in = URI.create(weeklyUrl).toURL().openStream()) {
+                Files.copy(in, into.get().toPath().resolve(fileName));
+            }
+        } catch (Exception e) {
+            throw new ZapDownloadWeeklyException("Failed to download: " + e.getMessage(), e);
+        }
+    }
+
+    public static class ZapDownloadWeeklyException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        ZapDownloadWeeklyException(String message) {
+            super(message);
+        }
+
+        ZapDownloadWeeklyException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapShutdown.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapShutdown.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.tasks;
+
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/** A task that shuts down ZAP through the API. */
+public class ZapShutdown extends ZapApiTask {
+
+    @TaskAction
+    public void shutdown() {
+        try {
+            createClient().core.shutdown();
+        } catch (ClientApiException e) {
+            throw new ZapShutdownException("Failed to shutdown ZAP: " + e.getMessage(), e);
+        }
+    }
+
+    public static class ZapShutdownException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        ZapShutdownException(String message) {
+            super(message);
+        }
+
+        ZapShutdownException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapStart.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapStart.java
@@ -1,0 +1,167 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.tasks;
+
+import static java.util.Arrays.asList;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.tools.ant.taskdefs.condition.Os;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/** A task that starts ZAP. */
+public class ZapStart extends ZapApiTask {
+
+    private static final int DEFAULT_TIMEOUT = 20;
+
+    private static final String DIR_ARG = "-dir";
+    private static final String PORT_ARG = "-port";
+    private static final String CONFIG_ARG = "-config";
+
+    private static final String API_KEY_CONFIG = "api.key";
+    private static final String API_DISABLE_KEY_CONFIG = "api.disablekey";
+
+    private static final String LINUX_START_SCRIPT = "./zap.sh";
+    private static final String WINDOWS_START_SCRIPT = "zap.bat";
+
+    private final Property<File> installDir;
+    private final Property<File> homeDir;
+    private final ListProperty<String> args;
+    private final Property<Integer> timeout;
+
+    public ZapStart() {
+        ObjectFactory objects = getProject().getObjects();
+        installDir = objects.property(File.class);
+        homeDir = objects.property(File.class);
+        args = objects.listProperty(String.class);
+        timeout = objects.property(Integer.class);
+        timeout.set(DEFAULT_TIMEOUT);
+    }
+
+    @Input
+    public Property<File> getInstallDir() {
+        return installDir;
+    }
+
+    @Input
+    public Property<File> getHomeDir() {
+        return homeDir;
+    }
+
+    @Input
+    @Optional
+    public ListProperty<String> getArgs() {
+        return args;
+    }
+
+    @Input
+    public Property<Integer> getTimeout() {
+        return timeout;
+    }
+
+    @TaskAction
+    public void start() {
+        getProject().mkdir(homeDir.get());
+
+        validateTimeout(timeout.get());
+
+        ClientApi client = createClient();
+        checkPortNotUsed(client);
+
+        ProcessBuilder pb = new ProcessBuilder();
+        pb.redirectErrorStream(true)
+                .redirectOutput(new File(homeDir.get(), "output"))
+                .directory(installDir.get());
+
+        List<String> command = new ArrayList<>();
+        command.add(Os.isFamily(Os.FAMILY_WINDOWS) ? WINDOWS_START_SCRIPT : LINUX_START_SCRIPT);
+        command.addAll(asList(DIR_ARG, homeDir.get().toString()));
+        command.addAll(asList(PORT_ARG, Integer.toString(getPort().get())));
+        boolean apiKeyPresent = getApiKey().isPresent();
+        if (apiKeyPresent) {
+            command.addAll(asList(CONFIG_ARG, API_KEY_CONFIG + "=" + getApiKey().get()));
+        }
+        command.addAll(asList(CONFIG_ARG, API_DISABLE_KEY_CONFIG + "=" + !apiKeyPresent));
+
+        if (args.isPresent()) {
+            command.addAll(args.get());
+        }
+        pb.command(command);
+
+        getLogger().debug("Starting ZAP in {} with {}", installDir.get(), pb.command());
+
+        try {
+            pb.start().waitFor(timeout.get(), TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new ZapStartException("Interrupted while waiting for ZAP to start.", e);
+        } catch (IOException e) {
+            throw new ZapStartException(
+                    "An error occurred while starting ZAP: " + e.getMessage(), e);
+        }
+
+        try {
+            client.waitForSuccessfulConnectionToZap(timeout.get());
+        } catch (ClientApiException e) {
+            throw new ZapStartException(
+                    String.format(
+                            "ZAP did not fully start after %1d seconds, cause: %2s",
+                            timeout.get(), e.getMessage()),
+                    e);
+        }
+    }
+
+    private static void checkPortNotUsed(ClientApi client) {
+        try {
+            client.waitForSuccessfulConnectionToZap(1);
+            throw new ZapStartException("The port is already in use, is ZAP already running?");
+        } catch (ClientApiException e) {
+            // Ignore, the port is not in use.
+        }
+    }
+
+    private static void validateTimeout(int timeout) {
+        if (timeout <= 0) {
+            throw new ZapStartException("The timeout must be greater than zero.");
+        }
+    }
+
+    public static class ZapStartException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        ZapStartException(String message) {
+            super(message);
+        }
+
+        ZapStartException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}


### PR DESCRIPTION
Change `zapDownload` and `zapStop` to not depend on external programs,
rely just on Java.
Change `runZap` and `zapStart` to use the appropriate start script
depending on the OS.

Other changes:
 - Extract tasks into `buildSrc` to make the build script leaner;
 - `zapDownload` will be skipped if the install dir already exists;
 - `zapStop` will fail if ZAP was not stopped and inform about the
 reason;
 - `runZap` and `zapStart` will:
   - Fail if the ZAP port is already in use, to ensure that it's used the
  expected ZAP instance;
   - Try connect to ZAP after starting the process to ensure that ZAP is
  running, failing otherwise;
   - Consume the output of the process to prevent hangs, now written to a
  file in the home dir.
 - Tweak Travis CI configuration to not call `zapDownload`, it's now a
 dependency of `zapStart`.