### PR TITLE
Set stricter compilation in buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     id("com.diffplug.gradle.spotless") version "3.15.0"
 }
 
+apply(from = "../gradle/compile.gradle.kts")
+
 gradlePlugin {
     plugins {
         register("zap-add-on-plugin") {


### PR DESCRIPTION
Handle compilation warnings as errors, same behaviour as in the main
code.