### PR TITLE
Enablers for reproducible builds

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/gradle/AddOnPlugin.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/AddOnPlugin.java
@@ -136,6 +136,9 @@ public class AddOnPlugin implements Plugin<Project> {
                     task.setDestinationDir(
                             project.getLayout().getBuildDirectory().dir("zap").get().getAsFile());
 
+                    task.setPreserveFileTimestamps(false);
+                    task.setReproducibleFileOrder(true);
+
                     Jar jar =
                             project.getTasks()
                                     .withType(Jar.class)


### PR DESCRIPTION
Change `assembleZapAddOn` to use a fixed timestamp for the files and
have them in a predictable order. Assuming same line endings in the
files all other state (e.g. built classes, generated files) should be
equal allowing to reproduce the builds/add-on.