### PR TITLE
Add task to copy the add-on to zaproxy

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/gradle/AddOnPlugin.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/AddOnPlugin.java
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.zaproxy.gradle.jh.JavaHelpIndexerExtension;
 import org.zaproxy.gradle.jh.tasks.JavaHelpIndexer;
+import org.zaproxy.gradle.tasks.CopyAddOn;
 import org.zaproxy.gradle.tasks.CopyZapHome;
 import org.zaproxy.gradle.tasks.UpdateManifestFile;
 
@@ -249,6 +250,17 @@ public class AddOnPlugin implements Plugin<Project> {
 
                     task.from(generateAddOnProvider, spec -> spec.into("plugin"));
                     task.from(extension.getZapHomeFiles());
+                });
+
+        TaskProvider<CopyAddOn> copyAddOnProvider =
+                project.getTasks().register("copyAddOn", CopyAddOn.class);
+        copyAddOnProvider.configure(
+                task -> {
+                    task.setGroup("ZAP Add-On");
+                    task.setDescription(
+                            "Copies the add-on to zaproxy project (defaults to \"../zaproxy/src/plugin/\").");
+
+                    task.from(generateAddOnProvider);
                 });
     }
 }

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/CopyAddOn.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/CopyAddOn.java
@@ -1,0 +1,42 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.tasks;
+
+import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.options.Option;
+
+/**
+ * A task to copy the add-on to a directory.
+ *
+ * <p>Defaults to {@code ../zaproxy/src/plugin/}.
+ */
+public class CopyAddOn extends Copy {
+
+    private static final String DEFAULT_DIR = "../zaproxy/src/plugin/";
+
+    public CopyAddOn() {
+        into(DEFAULT_DIR);
+    }
+
+    @Option(option = "into", description = "The file system path to the directory.")
+    public void optionInto(String dir) {
+        into(getProject().file(dir));
+    }
+}


### PR DESCRIPTION
Add task `copyAddOn` that copies the add-on to `../zaproxy/src/plugin/`
by default (can be overridden with command line argument `--into`).