### PR TITLE
Add task to generate ZapVersions data

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,10 @@ zapAddOn {
     zapHomeFiles.from(generatedI18nJsFileDir)
 
     zapVersion.set("2.8.0")
+
+    versions {
+        downloadUrl.set("https://github.com/zaproxy/zap-hud/releases/download/v$version")
+    }
 }
 
 tasks.named<UpdateManifestFile>("updateManifestFile") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,6 +21,9 @@ repositories {
 }
 
 dependencies {
+    implementation("commons-codec:commons-codec:1.11")
+    implementation("commons-configuration:commons-configuration:1.9")
+    implementation("commons-jxpath:commons-jxpath:1.3")
     implementation("org.apache.commons:commons-lang3:3.8.1")
     implementation("org.zaproxy:zap-clientapi:1.6.0")
 }

--- a/buildSrc/src/main/java/org/zaproxy/gradle/AddOnPlugin.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/AddOnPlugin.java
@@ -40,6 +40,8 @@ import org.zaproxy.gradle.jh.tasks.JavaHelpIndexer;
 import org.zaproxy.gradle.tasks.CopyAddOn;
 import org.zaproxy.gradle.tasks.DeployAddOn;
 import org.zaproxy.gradle.tasks.UpdateManifestFile;
+import org.zaproxy.gradle.zapversions.VersionsExtension;
+import org.zaproxy.gradle.zapversions.tasks.GenerateZapVersionsFile;
 
 public class AddOnPlugin implements Plugin<Project> {
 
@@ -94,6 +96,7 @@ public class AddOnPlugin implements Plugin<Project> {
                             setUpAddOnFiles(project, extension);
                             setUpManifest(project, extension);
                             setUpJavaHelp(project, jp, extension);
+                            setUpZapVersions(project, extension);
                         });
     }
 
@@ -266,5 +269,30 @@ public class AddOnPlugin implements Plugin<Project> {
 
                     task.from(generateAddOnProvider);
                 });
+    }
+
+    private static void setUpZapVersions(Project project, AddOnPluginExtension extension) {
+        TaskProvider<GenerateZapVersionsFile> tp =
+                project.getTasks()
+                        .register("generateZapVersionsFile", GenerateZapVersionsFile.class);
+        tp.configure(
+                t -> {
+                    TaskProvider<Jar> addOnProvider =
+                            project.getTasks().withType(Jar.class).named("assembleZapAddOn");
+                    t.dependsOn(addOnProvider);
+
+                    VersionsExtension zapVersionsExtension = extension.getVersions();
+                    t.getAddOnId().set(zapVersionsExtension.getAddOnId());
+                    t.getAddOn().set(addOnProvider.map(jar -> jar.getArchivePath()));
+                    t.getDownloadUrl().set(zapVersionsExtension.getDownloadUrl());
+                    t.getChecksumAlgorithm().set(zapVersionsExtension.getChecksumAlgorithm());
+                    t.getFile().set(zapVersionsExtension.getFile());
+
+                    t.setDescription("");
+                    t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+                });
+        project.getTasks()
+                .named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME)
+                .configure(t -> t.dependsOn(tp));
     }
 }

--- a/buildSrc/src/main/java/org/zaproxy/gradle/AddOnPluginExtension.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/AddOnPluginExtension.java
@@ -19,10 +19,12 @@
  */
 package org.zaproxy.gradle;
 
+import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
 import org.zaproxy.gradle.jh.JavaHelpIndexerExtension;
+import org.zaproxy.gradle.zapversions.VersionsExtension;
 
 public class AddOnPluginExtension {
 
@@ -32,6 +34,7 @@ public class AddOnPluginExtension {
     private final Property<String> zapVersion;
     private final JavaHelpIndexerExtension jhindexer;
     private final ConfigurableFileCollection zapHomeFiles;
+    private final VersionsExtension versions;
 
     public AddOnPluginExtension(Project project) {
         this.addOnId = project.getObjects().property(String.class);
@@ -43,6 +46,8 @@ public class AddOnPluginExtension {
         this.zapVersion = project.getObjects().property(String.class);
         this.jhindexer = project.getObjects().newInstance(JavaHelpIndexerExtension.class, project);
         this.zapHomeFiles = project.files();
+        this.versions = project.getObjects().newInstance(VersionsExtension.class, project);
+        this.versions.getAddOnId().set(addOnId);
     }
 
     public Property<String> getAddOnId() {
@@ -67,5 +72,13 @@ public class AddOnPluginExtension {
 
     public ConfigurableFileCollection getZapHomeFiles() {
         return zapHomeFiles;
+    }
+
+    public VersionsExtension getVersions() {
+        return versions;
+    }
+
+    public void versions(Action<? super VersionsExtension> action) {
+        action.execute(versions);
     }
 }

--- a/buildSrc/src/main/java/org/zaproxy/gradle/zapversions/VersionsExtension.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/zapversions/VersionsExtension.java
@@ -1,0 +1,75 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.zapversions;
+
+import java.io.File;
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+
+public class VersionsExtension {
+
+    private static final String ZAP_VERSIONS_XML = "ZapVersions.xml";
+
+    private final Property<String> addOnId;
+    private final Property<File> addOn;
+    private final Property<String> downloadUrl;
+    private final Property<String> checksumAlgorithm;
+    private final Property<File> file;
+
+    @Inject
+    public VersionsExtension(Project project) {
+        ObjectFactory objects = project.getObjects();
+        this.addOnId = objects.property(String.class);
+        this.addOnId.set(project.getName());
+        this.addOn = objects.property(File.class);
+        ;
+        this.downloadUrl = objects.property(String.class);
+        this.checksumAlgorithm = objects.property(String.class);
+        this.checksumAlgorithm.set("SHA1");
+        this.file = objects.property(File.class);
+        this.file.set(
+                project.getLayout()
+                        .getBuildDirectory()
+                        .file(ZAP_VERSIONS_XML)
+                        .map(t -> t.getAsFile()));
+    }
+
+    public Property<String> getAddOnId() {
+        return addOnId;
+    }
+
+    public Property<File> getAddOn() {
+        return addOn;
+    }
+
+    public Property<String> getDownloadUrl() {
+        return downloadUrl;
+    }
+
+    public Property<String> getChecksumAlgorithm() {
+        return checksumAlgorithm;
+    }
+
+    public Property<File> getFile() {
+        return file;
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/zapversions/tasks/GenerateZapVersionsFile.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/zapversions/tasks/GenerateZapVersionsFile.java
@@ -1,0 +1,257 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.zapversions.tasks;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.commons.configuration.XMLConfiguration;
+import org.apache.commons.configuration.tree.xpath.XPathExpressionEngine;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+public class GenerateZapVersionsFile extends DefaultTask {
+
+    private static final String NAME_ELEMENT = "name";
+    private static final String VERSION_ELEMENT = "version";
+    private static final String SEM_VER_ELEMENT = "semver";
+    private static final String DESCRIPTION_ELEMENT = "description";
+    private static final String AUTHOR_ELEMENT = "author";
+    private static final String URL_ELEMENT = "url";
+    private static final String CHANGES_ELEMENT = "changes";
+    private static final String NOT_BEFORE_VERSION_ELEMENT = "not-before-version";
+    private static final String NOT_FROM_VERSION_ELEMENT = "not-from-version";
+
+    private static final String DEPENDENCIES_ELEMENT = "dependencies";
+    private static final String DEPENDENCIES_JAVA_VERSION_ELEMENT = "javaversion";
+    private static final String DEPENDENCIES_ADDONS_ALL_ELEMENTS = "addons/addon";
+    private static final String DEPENDENCIES_ADDONS_ALL_ELEMENTS_NO_XPATH = "addons.addon";
+    private static final String ZAPADDON_ID_ELEMENT = "id";
+    private static final String ZAPADDON_NOT_BEFORE_VERSION_ELEMENT = "not-before-version";
+    private static final String ZAPADDON_NOT_FROM_VERSION_ELEMENT = "not-from-version";
+    private static final String ZAPADDON_SEMVER_ELEMENT = "semver";
+
+    private static final String ADD_ON_ELEMENT = "addon";
+    private static final String ADD_ON_NODE = "addon_";
+
+    private static final String FILE_ELEMENT = "file";
+    private static final String STATUS_ELEMENT = "status";
+    private static final String HASH_ELEMENT = "hash";
+    private static final String INFO_ELEMENT = "info";
+    private static final String SIZE_ELEMENT = "size";
+    private static final String DATE_ELEMENT = "date";
+
+    private final Property<String> addOnId;
+    private final Property<File> addOn;
+    private final Property<String> downloadUrl;
+    private final Property<String> checksumAlgorithm;
+    private final Property<File> file;
+
+    public GenerateZapVersionsFile() {
+        ObjectFactory objects = getProject().getObjects();
+        this.addOnId = objects.property(String.class);
+        this.addOn = objects.property(File.class);
+        this.downloadUrl = getProject().getObjects().property(String.class);
+        this.checksumAlgorithm = getProject().getObjects().property(String.class);
+        this.file = objects.property(File.class);
+    }
+
+    @Input
+    public Property<String> getAddOnId() {
+        return addOnId;
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public Property<File> getAddOn() {
+        return addOn;
+    }
+
+    @Input
+    public Property<String> getDownloadUrl() {
+        return downloadUrl;
+    }
+
+    @Input
+    public Property<String> getChecksumAlgorithm() {
+        return checksumAlgorithm;
+    }
+
+    @OutputFile
+    public Property<File> getFile() {
+        return file;
+    }
+
+    @TaskAction
+    public void generate() throws Exception {
+        File addOnFile = getAddOn().get();
+
+        XMLConfiguration zapAddOnXml = new XMLConfiguration();
+        try (ZipFile addOnZip = new ZipFile(addOnFile)) {
+            ZipEntry manifestEntry = addOnZip.getEntry("ZapAddOn.xml");
+            if (manifestEntry == null) {
+                throw new IllegalArgumentException(
+                        "The specified add-on does not have the manifest: " + addOnFile);
+            }
+
+            try (InputStream is = addOnZip.getInputStream(manifestEntry)) {
+                zapAddOnXml.setEncoding("UTF-8");
+                zapAddOnXml.setDelimiterParsingDisabled(true);
+                zapAddOnXml.setExpressionEngine(new XPathExpressionEngine());
+                zapAddOnXml.load(is);
+            }
+        }
+
+        XMLConfiguration zapVersionsXml =
+                new XMLConfiguration() {
+
+                    private static final long serialVersionUID = 7018390148134058207L;
+
+                    @Override
+                    protected Transformer createTransformer() throws TransformerException {
+                        Transformer transformer = super.createTransformer();
+                        transformer.setOutputProperty(
+                                "{http://xml.apache.org/xslt}indent-amount", "4");
+                        return transformer;
+                    }
+                };
+        zapVersionsXml.setEncoding("UTF-8");
+        zapVersionsXml.setDelimiterParsingDisabled(true);
+        zapVersionsXml.setRootElementName("ZAP");
+
+        zapVersionsXml.addProperty(ADD_ON_ELEMENT, getAddOnId().get());
+
+        String fileName = addOnFile.getName();
+        String hash = createChecksum(checksumAlgorithm.get(), addOnFile);
+
+        append(NAME_ELEMENT, zapAddOnXml, zapVersionsXml);
+        append(DESCRIPTION_ELEMENT, zapAddOnXml, zapVersionsXml);
+        append(AUTHOR_ELEMENT, zapAddOnXml, zapVersionsXml);
+        append(VERSION_ELEMENT, zapAddOnXml, zapVersionsXml);
+        append(SEM_VER_ELEMENT, zapAddOnXml, zapVersionsXml);
+        appendIfNotEmpty(fileName, zapVersionsXml, getAddOnNodeKey(FILE_ELEMENT));
+        append(STATUS_ELEMENT, zapAddOnXml, zapVersionsXml);
+        append(CHANGES_ELEMENT, zapAddOnXml, zapVersionsXml);
+        appendIfNotEmpty(
+                getDownloadUrl().get() + "/" + fileName,
+                zapVersionsXml,
+                getAddOnNodeKey(URL_ELEMENT));
+        appendIfNotEmpty(hash, zapVersionsXml, getAddOnNodeKey(HASH_ELEMENT));
+        append(URL_ELEMENT, zapAddOnXml, INFO_ELEMENT, zapVersionsXml);
+        appendIfNotEmpty(LocalDate.now().toString(), zapVersionsXml, getAddOnNodeKey(DATE_ELEMENT));
+        appendIfNotEmpty(
+                String.valueOf(addOnFile.length()), zapVersionsXml, getAddOnNodeKey(SIZE_ELEMENT));
+        append(NOT_BEFORE_VERSION_ELEMENT, zapAddOnXml, zapVersionsXml);
+        append(NOT_FROM_VERSION_ELEMENT, zapAddOnXml, zapVersionsXml);
+
+        appendDependencies(zapAddOnXml, zapVersionsXml);
+
+        zapVersionsXml.save(getFile().get());
+    }
+
+    private static String createChecksum(String algorithm, File addOnFile) throws IOException {
+        return algorithm + ":" + new DigestUtils(algorithm).digestAsHex(addOnFile);
+    }
+
+    private void append(String nameElement, XMLConfiguration from, XMLConfiguration to) {
+        append(nameElement, from, nameElement, to);
+    }
+
+    private void append(
+            String nameElement, XMLConfiguration from, String toNameElement, XMLConfiguration to) {
+        String value = from.getString(nameElement, "");
+        appendIfNotEmpty(value, to, getAddOnNodeKey(toNameElement));
+    }
+
+    private void appendIfNotEmpty(String value, XMLConfiguration to, String key) {
+        if (!value.isEmpty()) {
+            to.setProperty(key, value);
+        }
+    }
+
+    private String getAddOnNodeKey(String element) {
+        return ADD_ON_NODE + addOnId.get() + "." + element;
+    }
+
+    private void appendDependencies(XMLConfiguration from, XMLConfiguration to) {
+        List<HierarchicalConfiguration> dependencies = from.configurationsAt(DEPENDENCIES_ELEMENT);
+        if (dependencies.isEmpty()) {
+            return;
+        }
+
+        HierarchicalConfiguration node = dependencies.get(0);
+
+        appendIfNotEmpty(
+                node.getString(DEPENDENCIES_JAVA_VERSION_ELEMENT, ""),
+                to,
+                getAddOnNodeKey(DEPENDENCIES_ELEMENT + "." + DEPENDENCIES_JAVA_VERSION_ELEMENT));
+
+        List<HierarchicalConfiguration> fields =
+                node.configurationsAt(DEPENDENCIES_ADDONS_ALL_ELEMENTS);
+        if (fields.isEmpty()) {
+            return;
+        }
+
+        for (int i = 0, size = fields.size(); i < size; ++i) {
+            String elementBaseKey =
+                    getAddOnNodeKey(
+                                    DEPENDENCIES_ELEMENT
+                                            + "."
+                                            + DEPENDENCIES_ADDONS_ALL_ELEMENTS_NO_XPATH)
+                            + "("
+                            + i
+                            + ").";
+
+            HierarchicalConfiguration sub = fields.get(i);
+
+            appendIfNotEmpty(
+                    sub.getString(ZAPADDON_ID_ELEMENT, ""),
+                    to,
+                    elementBaseKey + ZAPADDON_ID_ELEMENT);
+            appendIfNotEmpty(
+                    sub.getString(ZAPADDON_SEMVER_ELEMENT, ""),
+                    to,
+                    elementBaseKey + ZAPADDON_SEMVER_ELEMENT);
+            appendIfNotEmpty(
+                    sub.getString(ZAPADDON_NOT_BEFORE_VERSION_ELEMENT, ""),
+                    to,
+                    elementBaseKey + ZAPADDON_NOT_BEFORE_VERSION_ELEMENT);
+            appendIfNotEmpty(
+                    sub.getString(ZAPADDON_NOT_FROM_VERSION_ELEMENT, ""),
+                    to,
+                    elementBaseKey + ZAPADDON_NOT_FROM_VERSION_ELEMENT);
+        }
+    }
+}


### PR DESCRIPTION
Add task `generateZapVersionsFile` to generate the data required to
release into the marketplace, generated in `build/ZapVersions.xml`.
The add-on/download will be in this repo, in the corresponding release.