### PR TITLE
Allow to start ZAP with different port

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapApiTask.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapApiTask.java
@@ -24,6 +24,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.options.Option;
 import org.zaproxy.clientapi.core.ClientApi;
 
 /** A task that accesses the ZAP API. */
@@ -55,6 +56,15 @@ public class ZapApiTask extends DefaultTask {
         return port;
     }
 
+    @Option(option = "port", description = "The port where ZAP is or will be listening.")
+    public void optionPort(String port) {
+        try {
+            getPort().set(Integer.parseInt(port));
+        } catch (NumberFormatException e) {
+            throwInvalidPort(port);
+        }
+    }
+
     @Input
     @Optional
     public Property<String> getApiKey() {
@@ -69,8 +79,14 @@ public class ZapApiTask extends DefaultTask {
 
     private static void validatePort(int port) {
         if (port <= 0 || port > 65535) {
-            throw new IllegalArgumentException(
-                    "The specified port is not valid, it should be > 0 and <= 65535.");
+            throwInvalidPort(port);
         }
+    }
+
+    private static void throwInvalidPort(Object port) {
+        throw new IllegalArgumentException(
+                String.format(
+                        "The specified port '%1s' is not valid, it should be > 0 and <= 65535.",
+                        port));
     }
 }

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapStart.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapStart.java
@@ -93,7 +93,7 @@ public class ZapStart extends ZapApiTask {
         validateTimeout(timeout.get());
 
         ClientApi client = createClient();
-        checkPortNotUsed(client);
+        checkPortNotUsed(client, getPort().get());
 
         ProcessBuilder pb = new ProcessBuilder();
         pb.redirectErrorStream(true)
@@ -140,10 +140,14 @@ public class ZapStart extends ZapApiTask {
         }
     }
 
-    private static void checkPortNotUsed(ClientApi client) {
+    private static void checkPortNotUsed(ClientApi client, int port) {
         try {
             client.waitForSuccessfulConnectionToZap(1);
-            throw new ZapStartException("The port is already in use, is ZAP already running?");
+            throw new ZapStartException(
+                    String.format(
+                            "The port %1d is already in use, is ZAP already running?"
+                                    + "\nThe port can be changed with --port command line argument.",
+                            port));
         } catch (ClientApiException e) {
             // Ignore, the port is not in use.
         }


### PR DESCRIPTION
Add a command line argument to ZapApiTask to override the port used to
connect to (and start) ZAP (e.g. `--port=8081`).
Provide more information in the exception messages of ZapApiTask and
ZapStart when the port is already in use or when invalid.