### PR TITLE
Tidy up task groups

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.zaproxy.gradle.AddOnPlugin
 import org.zaproxy.gradle.tasks.GenerateI18nJsFile
 import org.zaproxy.gradle.tasks.UpdateManifestFile
 import org.zaproxy.gradle.tasks.ZapDownloadWeekly
@@ -125,7 +126,7 @@ tasks {
     }
 
     register<Test>("testTutorial") { 
-        group = "Verification"
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
         description = "Runs the tutorial tests (ZAP must be running)."
         useJUnitPlatform { 
             includeTags("tutorial") 
@@ -133,7 +134,7 @@ tasks {
     }
 
     register<Test>("testRemote") { 
-        group = "Verification"
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
         description = "Runs the remote tests (ZAP must be running)."
         useJUnitPlatform { 
             includeTags("remote") 
@@ -141,7 +142,7 @@ tasks {
     }
 
     register<ZapDownloadWeekly>("zapDownload") {
-        group = "Verification"
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
         description = "Downloads the latest ZAP weekly release for the unit tests"
 
         onlyIf { !zapInstallDir.asFile.exists() }
@@ -161,7 +162,8 @@ tasks {
     }
 
     register<Copy>("copyHudClientFiles") {
-        description = "Copies the HUD files to the (local) home directory for use with continuous mode."
+        group = AddOnPlugin.ADD_ON_GROUP
+        description = "Copies the HUD files to runZap's home directory for use with continuous mode."
 
         from(file("src/main/zapHomeFiles"))
         from(sourceSets["main"].output.dirs)
@@ -169,6 +171,7 @@ tasks {
     }
 
     register<ZapStart>("runZap") {
+        group = AddOnPlugin.ADD_ON_GROUP
         description = "Runs ZAP (weekly) with the HUD in dev mode."
 
         dependsOn("zapDownload", "assembleZapAddOn", "copyHudClientFiles")

--- a/buildSrc/src/main/java/org/zaproxy/gradle/AddOnPlugin.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/AddOnPlugin.java
@@ -45,6 +45,8 @@ import org.zaproxy.gradle.zapversions.tasks.GenerateZapVersionsFile;
 
 public class AddOnPlugin implements Plugin<Project> {
 
+    public static final String ADD_ON_GROUP = "ZAP Add-On";
+
     public static final String EXTENSION_NAME = "zapAddOn";
 
     private static final String JAVA_HELP_DEFAULT_DEPENDENCY = "javax.help:javahelp:2.0.05";
@@ -247,7 +249,7 @@ public class AddOnPlugin implements Plugin<Project> {
                 project.getTasks().register("deploy", DeployAddOn.class);
         deployProvider.configure(
                 task -> {
-                    task.setGroup("ZAP Add-On");
+                    task.setGroup(ADD_ON_GROUP);
                     task.setDescription(
                             "Deploys the add-on and its home files to ZAP home dir.\n\n"
                                     + "Defaults to dev home dir if not specified through the command line nor\n"
@@ -266,7 +268,7 @@ public class AddOnPlugin implements Plugin<Project> {
                 project.getTasks().register("copyAddOn", CopyAddOn.class);
         copyAddOnProvider.configure(
                 task -> {
-                    task.setGroup("ZAP Add-On");
+                    task.setGroup(ADD_ON_GROUP);
                     task.setDescription(
                             "Copies the add-on to zaproxy project (defaults to \"../zaproxy/src/plugin/\").");
 


### PR DESCRIPTION
Set `runZap` and `copyHudClientFiles` in the same group as the other
add-on related tasks.
Tweak `copyHudClientFiles` description.
Use constants when setting the groups.