### PR TITLE
Create manifest changes from changelog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.zaproxy.gradle.AddOnPlugin
+import org.zaproxy.gradle.tasks.CreateManifestChanges
 import org.zaproxy.gradle.tasks.GenerateI18nJsFile
 import org.zaproxy.gradle.tasks.UpdateManifestFile
 import org.zaproxy.gradle.tasks.ZapDownloadWeekly
@@ -47,8 +48,14 @@ zapAddOn {
     }
 }
 
+val createManifestChanges by tasks.registering(CreateManifestChanges::class) {
+    changelog.set(file("CHANGELOG.md"))
+    manifestChanges.set(layout.buildDirectory.file("manifest-changes.html"))
+}
+
 tasks.named<UpdateManifestFile>("updateManifestFile") {
     baseManifest.set(file("src/other/resources/ZapAddOn.xml"))
+    changes.set(createManifestChanges.get().manifestChanges)
     outputDir.set(genHudFilesDir.dir("manifest"))
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,7 +25,14 @@ dependencies {
     implementation("commons-configuration:commons-configuration:1.9")
     implementation("commons-jxpath:commons-jxpath:1.3")
     implementation("org.apache.commons:commons-lang3:3.8.1")
+    implementation("org.apache.commons:commons-text:1.6")
     implementation("org.zaproxy:zap-clientapi:1.6.0")
+
+    val flexmarkVersion = "0.35.0"
+    implementation("com.vladsch.flexmark:flexmark-java:$flexmarkVersion")
+    implementation("com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:$flexmarkVersion")
+    implementation("com.vladsch.flexmark:flexmark-ext-gfm-tasklist:$flexmarkVersion")
+    implementation("com.vladsch.flexmark:flexmark-ext-tables:$flexmarkVersion")
 }
 
 java {

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/CreateManifestChanges.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/CreateManifestChanges.java
@@ -1,0 +1,124 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.tasks;
+
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughSubscriptExtension;
+import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.options.MutableDataSet;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+/** A task that creates manifest changes from a changelog. */
+public class CreateManifestChanges extends DefaultTask {
+
+    private static final int CHANGELOG_CHUNK_SIZE = 20_000;
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("## \\[.+\\].*\\R");
+    private static final Pattern VERSION_LINK_PATTERN = Pattern.compile("\\[.+\\]:");
+
+    private final RegularFileProperty changelog;
+    private final RegularFileProperty manifestChanges;
+
+    public CreateManifestChanges() {
+        changelog = newInputFile();
+        manifestChanges = newOutputFile();
+    }
+
+    @InputFile
+    public RegularFileProperty getChangelog() {
+        return changelog;
+    }
+
+    @OutputFile
+    public RegularFileProperty getManifestChanges() {
+        return manifestChanges;
+    }
+
+    @TaskAction
+    public void create() throws Exception {
+        MutableDataSet options = new MutableDataSet();
+        options.set(
+                Parser.EXTENSIONS,
+                Arrays.asList(
+                        StrikethroughSubscriptExtension.create(),
+                        TablesExtension.create(),
+                        TaskListExtension.create()));
+
+        Parser parser = Parser.builder(options).build();
+        HtmlRenderer renderer = HtmlRenderer.builder(options).build();
+
+        String changes = getChanges(changelog.get().getAsFile().toPath());
+        try (Writer writer = Files.newBufferedWriter(manifestChanges.get().getAsFile().toPath())) {
+            renderer.render(parser.parse(changes), writer);
+        }
+    }
+
+    private String getChanges(Path changelog) throws IOException {
+        return extractChangesLatestVersion(readChunk(changelog));
+    }
+
+    private static String readChunk(Path changelog) throws IOException {
+        char[] chars = new char[CHANGELOG_CHUNK_SIZE];
+        int n;
+        try (Reader reader = Files.newBufferedReader(changelog)) {
+            n = reader.read(chars);
+        }
+        if (n == -1) {
+            throw new IOException("Failed to read any characters from: " + changelog);
+        }
+        return new String(chars, 0, n);
+    }
+
+    private String extractChangesLatestVersion(String contents) {
+        Matcher matcher = VERSION_PATTERN.matcher(contents);
+        if (!matcher.find()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "No version matching '%1s' was found in changelog:\n%2s",
+                            VERSION_PATTERN, contents));
+        }
+        int changesStart = matcher.end();
+        if (!matcher.find()) {
+            getLogger().debug("Second version not found, fallback to version link.");
+            matcher = VERSION_LINK_PATTERN.matcher(contents);
+            if (!matcher.find()) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "No version matching '%1s' nor version link matching '%2s' was found in changelog:\n%3s",
+                                VERSION_PATTERN, VERSION_LINK_PATTERN, contents));
+            }
+        }
+        return contents.substring(changesStart, matcher.start());
+    }
+}

--- a/src/other/resources/ZapAddOn.xml
+++ b/src/other/resources/ZapAddOn.xml
@@ -5,10 +5,7 @@
 	<description>Display information from ZAP in browser.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>
-	<![CDATA[
-	]]>
-	</changes>
+	<changes>@changes@</changes>
 	<dependencies>
 		<addons>
 			<addon>


### PR DESCRIPTION
Add task, `createManifestChanges`, to extract the contents from the
latest version in the changelog, convert to HTML, and write to a file.
Change task `updateManifestFile` to read the changes from the file.