### PR TITLE
Add task to install the add-on into running ZAP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,10 @@ import org.zaproxy.gradle.AddOnPlugin
 import org.zaproxy.gradle.tasks.GenerateI18nJsFile
 import org.zaproxy.gradle.tasks.UpdateManifestFile
 import org.zaproxy.gradle.tasks.ZapDownloadWeekly
+import org.zaproxy.gradle.tasks.ZapInstallAddOn
 import org.zaproxy.gradle.tasks.ZapStart
 import org.zaproxy.gradle.tasks.ZapShutdown
+import org.zaproxy.gradle.tasks.ZapUninstallAddOn
 
 plugins {
     `java-library`
@@ -180,6 +182,22 @@ tasks {
         homeDir.set(zapHome.asFile)
 
         args.set(listOf("-dev", "-config", "start.checkForUpdates=false", "-config", "start.addonDirs=$buildDir/zap/", "-config", "hud.dir=$zapHome/hud") + hudDevArgs)
+    }
+
+    val assembleZapAddOn = tasks.named<Jar>("assembleZapAddOn");
+    val uninstallAddOn by registering(ZapUninstallAddOn::class) {
+        group = AddOnPlugin.ADD_ON_GROUP
+        description = "Uninstalls the add-on from ZAP (started with \"runZap\")."
+        addOnId.set(zapAddOn.addOnId)
+    }
+    assembleZapAddOn.configure { mustRunAfter(uninstallAddOn) }
+
+    register<ZapInstallAddOn>("installAddOn") {
+        group = AddOnPlugin.ADD_ON_GROUP
+        description = "Installs the add-on into ZAP (started with \"runZap\")."
+
+        dependsOn(uninstallAddOn, assembleZapAddOn)
+        addOn.set(assembleZapAddOn.get().archivePath)
     }
 
     register<ZapStart>("zapStart") {

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapInstallAddOn.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapInstallAddOn.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.tasks;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.clientapi.core.ApiResponseElement;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/** A task that installs an add-on into ZAP. */
+public class ZapInstallAddOn extends ZapApiTask {
+
+    private final RegularFileProperty addOn;
+
+    public ZapInstallAddOn() {
+        addOn = newInputFile();
+    }
+
+    @InputFile
+    public RegularFileProperty getAddOn() {
+        return addOn;
+    }
+
+    @TaskAction
+    public void start() {
+        ClientApi client = createClient();
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("file", getAddOn().get().getAsFile().toString());
+        try {
+            if (ApiResponseElement.FAIL.equals(
+                    client.callApi("autoupdate", "action", "installLocalAddon", parameters))) {
+                throw new ZapInstallAddOnException(
+                        "Failed to install the add-on, check ZAP log for more details.");
+            }
+        } catch (ClientApiException e) {
+            throw new ZapInstallAddOnException(
+                    "An error occurred while installing the add-on: " + e.getMessage(), e);
+        }
+    }
+
+    public static class ZapInstallAddOnException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        ZapInstallAddOnException(String message) {
+            super(message);
+        }
+
+        ZapInstallAddOnException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapUninstallAddOn.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ZapUninstallAddOn.java
@@ -1,0 +1,80 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.tasks;
+
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ApiResponseList;
+import org.zaproxy.clientapi.core.ApiResponseSet;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+/** A task that uninstalls an add-on from ZAP. */
+public class ZapUninstallAddOn extends ZapApiTask {
+
+    private final Property<String> addOnId;
+
+    public ZapUninstallAddOn() {
+        addOnId = getProject().getObjects().property(String.class);
+    }
+
+    @Input
+    public Property<String> getAddOnId() {
+        return addOnId;
+    }
+
+    @TaskAction
+    public void start() {
+        ClientApi client = createClient();
+        try {
+            String id = getAddOnId().get();
+            if (hasAddOn(client.autoupdate.installedAddons(), id)) {
+                client.autoupdate.uninstallAddon(id);
+            }
+        } catch (ClientApiException e) {
+            throw new ZapUninstallAddOnException(
+                    "Failed to uninstall the old version of the add-on: " + e.getMessage(), e);
+        }
+    }
+
+    private static boolean hasAddOn(ApiResponse addOns, String addOnId) {
+        for (ApiResponse addOnData : ((ApiResponseList) addOns).getItems()) {
+            if (addOnId.equals(((ApiResponseSet) addOnData).getStringValue("id"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static class ZapUninstallAddOnException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        ZapUninstallAddOnException(String message) {
+            super(message);
+        }
+
+        ZapUninstallAddOnException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}


### PR DESCRIPTION
Add a task `installAddOn` that installs the add-on into ZAP (started
with `runZap`), to allow to apply add-on changes without restarting ZAP
(which takes more time than un/install the add-on).

---
Requires zaproxy/zaproxy#5157.