### PR TITLE
Add 2nd non SameSite cookie for safer API calls - WIP

### DIFF
--- a/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -63,7 +63,8 @@ import org.zaproxy.zap.extension.websocket.ExtensionWebSocket;
 
 public class HudAPI extends ApiImplementor {
 
-    public static final String ZAP_HUD_COOKIE = "ZAP-HUD";
+    public static final String ZAP_HUD_STRICT_COOKIE = "ZAP-HUD-STRICT";
+    public static final String ZAP_HUD_SAFE_COOKIE = "ZAP-HUD-SAFE";
 
     // TODO shouldnt allow unsafe-inline styles - need to work out where they are being used
     protected static final String CSP_POLICY =
@@ -110,7 +111,9 @@ public class HudAPI extends ApiImplementor {
     private final String sharedSecret = UUID.randomUUID().toString();
 
     /** Cookie used on the ZAP domain - should never be exposed to a target site. */
-    private final String zapHudCookie = UUID.randomUUID().toString();
+    private final String zapHudSafeCookie = UUID.randomUUID().toString();
+
+    private final String zapHudStrictCookie = UUID.randomUUID().toString();
 
     private static Logger logger = Logger.getLogger(HudAPI.class);
 
@@ -477,8 +480,12 @@ public class HudAPI extends ApiImplementor {
         return websocketUrl;
     }
 
-    protected String getZapHudCookieValue() {
-        return zapHudCookie;
+    protected String getZapHudSafeCookieValue() {
+        return zapHudSafeCookie;
+    }
+
+    protected String getZapHudStrictCookieValue() {
+        return zapHudStrictCookie;
     }
 
     public String getRequestCookieValue(HttpMessage msg, String cookieName) {

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudFileProxy.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudFileProxy.java
@@ -123,16 +123,27 @@ public class HudFileProxy extends ApiImplementor {
                                     .setHeader("Content-Security-Policy", HudAPI.CSP_POLICY);
                         }
                     }
-                    if (api.getRequestCookieValue(msg, HudAPI.ZAP_HUD_COOKIE) == null) {
-                        // The ZAP-HUD cookie has not been set, so set it or we'll block access to
-                        // key resources
+                    if (api.getRequestCookieValue(msg, HudAPI.ZAP_HUD_STRICT_COOKIE) == null) {
+                        // The ZAP-HUD strict cookie has not been set, so set it or we'll block
+                        // access to key resources
                         msg.getResponseHeader()
                                 .setHeader(
                                         HttpHeader.SET_COOKIE,
-                                        HudAPI.ZAP_HUD_COOKIE
+                                        HudAPI.ZAP_HUD_STRICT_COOKIE
                                                 + "="
-                                                + api.getZapHudCookieValue()
-                                                + "; Secure; HttpOnly; SameSite=Strict");
+                                                + api.getZapHudStrictCookieValue()
+                                                + "; Path=/; Secure; HttpOnly; SameSite=Strict");
+                    }
+                    if (api.getRequestCookieValue(msg, HudAPI.ZAP_HUD_SAFE_COOKIE) == null) {
+                        // The ZAP-HUD safe cookie has not been set, so set it or we'll block access
+                        // to key resources
+                        msg.getResponseHeader()
+                                .setHeader(
+                                        HttpHeader.SET_COOKIE,
+                                        HudAPI.ZAP_HUD_SAFE_COOKIE
+                                                + "="
+                                                + api.getZapHudSafeCookieValue()
+                                                + "; Path=/; Secure; HttpOnly;");
                     }
 
                     return msg.getResponseBody().toString();


### PR DESCRIPTION
Fixes #326 

The reason for the "WIP" is because it looks to me like some of the API requests coming from the display do have the SameSite cookie attached :/
A good example is the Sites tree tool - the display appears to be making direct API calls https://github.com/zaproxy/zap-hud/blob/develop/src/main/zapHomeFiles/hud/display.js#L458 and these do have the SameSite cookie :/

Thoughts appreciated...