### PR TITLE
Clean up a few things from multi tab (refactor)

### DIFF
--- a/src/main/zapHomeFiles/hud/management.js
+++ b/src/main/zapHomeFiles/hud/management.js
@@ -92,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		navigator.serviceWorker.addEventListener('message', serviceWorkerMessageListener)
 
 		// send targetload message 
-		navigator.serviceWorker.controller.postMessage({action:"targetload", targetUrl: context.url});
+		navigator.serviceWorker.controller.postMessage({action: 'targetload', tabId: tabId, targetUrl: context.url});
 
 		localforage.setItem(IS_SERVICEWORKER_REFRESHED, true);
 	}

--- a/src/main/zapHomeFiles/hud/serviceworker.js
+++ b/src/main/zapHomeFiles/hud/serviceworker.js
@@ -242,7 +242,7 @@ function showAddToolDialog(tabId, frameId) {
 			config.tools = tools;
 
 			// display tools to select
-			return utils.messageFrame2(tabId, "display", {action: "showAddToolList", config: config})
+			return utils.messageFrame(tabId, "display", {action: "showAddToolList", config: config})
 		})
 		.then(response => {
 			utils.addToolToPanel(response.toolname, frameId);
@@ -256,7 +256,7 @@ function showHudSettings(tabId) {
 		initialize: I18n.t("settings_resets"),
 	};
 
-	utils.messageFrame2(tabId, "display", {action: "showHudSettings", config: config})
+	utils.messageFrame(tabId, "display", {action: "showHudSettings", config: config})
 		.then(response => {
 			if (response.id === "initialize") {
 				resetToDefault();

--- a/src/main/zapHomeFiles/hud/serviceworker.js
+++ b/src/main/zapHomeFiles/hud/serviceworker.js
@@ -99,11 +99,6 @@ const onFetch = event => {
 			.then(response => {  
 
 				if (response) {
-					// save the frame id as a destination for postmesssaging later
-					if (event.request.url.endsWith(".js")) {
-						saveFrameId(event);
-					}
-
 					return response;
 				}
 				else {
@@ -181,40 +176,6 @@ webSocket.onerror = function (event) {
 
 function registerForZapEvents(publisher) {
 	webSocket.send('{"component" : "event", "type" : "register", "name" : "' + publisher + '"}');
-};
-
-/*
- * Saves the clientId of a window which is used to send postMessages.
- */
-function saveFrameId(event) {
-
-	let frameNames = {
-		"management.html": "management",
-		"panel.html": "Panel",
-		"display.html": "display",
-		"growlerAlerts.html": "growlerAlerts",
-		"drawer.html": "drawer"
-	};
-
-	clients.get(event.clientId)
-		.then(client => {
-			let params = new URL(client.url).searchParams;
-
-			let key = frameNames[params.get('name')];
-
-			if (key === "Panel") {
-				key = params.get('orientation') + key;
-			}
-
-			utils.loadFrame(key)
-				.then(frame => {
-					frame.clientId = client.id;
-
-					return utils.saveFrame(frame);
-				})
-				.catch(utils.errorHandler)
-		})
-		.catch(utils.errorHandler);
 };
 
 function showAddToolDialog(tabId, frameId) {

--- a/src/main/zapHomeFiles/hud/serviceworker.js
+++ b/src/main/zapHomeFiles/hud/serviceworker.js
@@ -278,6 +278,6 @@ function resetToDefault() {
 
 			return Promise.all(promises);
 		})
-		.then(utils.messageFrame("management", {action: "refreshTarget"}))
+		.then(utils.messageAllTabs("management", {action: "refreshTarget"}))
 		.catch(utils.errorHandler);
 };

--- a/src/main/zapHomeFiles/hud/tools/activeScan.js
+++ b/src/main/zapHomeFiles/hud/tools/activeScan.js
@@ -67,7 +67,7 @@ var ActiveScan = (function() {
 
 				return config;
 			})
-			.then(config => utils.messageFrame2(tabId, "display", {action:"showDialog", config:config}))
+			.then(config => utils.messageFrame(tabId, "display", {action:"showDialog", config:config}))
 			.then(response => {
 				// Handle button choice
 				if (response.id === "start") {
@@ -106,7 +106,7 @@ var ActiveScan = (function() {
 
 						utils.writeTool(tool);
 						utils.messageAllTabs(tool.panel, {action: 'broadcastUpdate', context: {notTabId: tabId}, tool: {name: NAME, label: LABEL, data: DATA.START, icon: ICONS.OFF}, isToolDisabled: true})
-						utils.messageFrame2(tabId, tool.panel, {action: 'updateData', tool: {name: NAME, label: LABEL, data: tool.data, icon: ICONS.ON}});
+						utils.messageFrame(tabId, tool.panel, {action: 'updateData', tool: {name: NAME, label: LABEL, data: tool.data, icon: ICONS.ON}});
 					})
 					.catch(utils.errorHandler)
 			})
@@ -160,7 +160,7 @@ var ActiveScan = (function() {
 						tool.data = progress;
 
 						utils.writeTool(tool);
-						utils.messageFrame2(tool.runningTabId, tool.panel, {action: 'updateData', tool: tool})
+						utils.messageFrame(tool.runningTabId, tool.panel, {action: 'updateData', tool: tool})
 					}
 				})
 				.catch(utils.errorHandler);
@@ -174,7 +174,7 @@ var ActiveScan = (function() {
 		config.toolLabel = LABEL;
 		config.options = {remove: I18n.t("common_remove")};
 
-		utils.messageFrame2(tabId, "display", {action:"showButtonOptions", config:config})
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {

--- a/src/main/zapHomeFiles/hud/tools/activeScan.js
+++ b/src/main/zapHomeFiles/hud/tools/activeScan.js
@@ -36,7 +36,7 @@ var ActiveScan = (function() {
 		tool.runningTabId = '';
 		tool.scanid = -1;
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 		registerForZapEvents(ACTIVE_SCAN_EVENT);
 	}
 

--- a/src/main/zapHomeFiles/hud/tools/attack.js
+++ b/src/main/zapHomeFiles/hud/tools/attack.js
@@ -61,7 +61,7 @@ var Attack = (function() {
 					];
 				}
 
-				utils.messageFrame2(tabId, "display", {action:"showDialog", config:config})
+				utils.messageFrame(tabId, "display", {action:"showDialog", config:config})
 					.then(response => {
 						// Handle button choice
 						if (response.id === "turnon") {
@@ -141,7 +141,7 @@ var Attack = (function() {
 		config.toolLabel = LABEL;
 		config.options = {remove: I18n.t("common_remove")};
 
-		utils.messageFrame2(tabId, "display", {action:"showButtonOptions", config:config})
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {

--- a/src/main/zapHomeFiles/hud/tools/attack.js
+++ b/src/main/zapHomeFiles/hud/tools/attack.js
@@ -33,7 +33,7 @@ var Attack = (function() {
 		tool.isRunning = false;
 		tool.attackingDomain = '';
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 	function showDialog(tabId, domain) {

--- a/src/main/zapHomeFiles/hud/tools/break.js
+++ b/src/main/zapHomeFiles/hud/tools/break.js
@@ -198,7 +198,7 @@ var Break = (function() {
 		config.toolLabel = LABEL;
 		config.options = {remove: I18n.t("common_remove"), filter: "Add Filter"};
 
-		utils.messageFrame2(tabId, "display", {action:"showButtonOptions", config:config})
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {

--- a/src/main/zapHomeFiles/hud/tools/commonAlerts.js
+++ b/src/main/zapHomeFiles/hud/tools/commonAlerts.js
@@ -27,7 +27,7 @@ var CommonAlerts = (function() {
 		tool.position = 0;
 		tool.alerts = {};
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 		registerForZapEvents("org.zaproxy.zap.extension.alert.AlertEventPublisher");
 		registerForZapEvents("org.zaproxy.zap.extension.hud.HudEventPublisher");
 	}
@@ -115,7 +115,7 @@ var CommonAlerts = (function() {
 					.then(json => {
 						alertCache[targetDomain] = alertUtils.flattenAllAlerts(json);
 						tool.alerts = alertCache;
-						return utils.saveTool(tool);
+						return utils.writeTool(tool);
 					})
 					.then(() => {
 						// Raise the events after the data is saved
@@ -155,7 +155,7 @@ var CommonAlerts = (function() {
 										var alert = pageAlerts[alertRisk][alertName][i];
 										if (alert.param.length > 0 && ! reportedParams.has(alert.param)) {
 											reportedParams.add(alert.param);
-											utils.messageFrame("management", {
+											utils.messageFrame2(event.detail.tabId, "management", {
 												action: "commonAlerts.alert",
 												name: alert.name,
 												id: alert.id,
@@ -220,7 +220,6 @@ var CommonAlerts = (function() {
 						// backup to localstorage in case the serviceworker dies
 						tool.alerts = alertCache;
 						return utils.writeTool(tool);
-						//return utils.saveTool(tool);
 					})
 					.then(() => {
 						// Raise the event after the data is saved

--- a/src/main/zapHomeFiles/hud/tools/commonAlerts.js
+++ b/src/main/zapHomeFiles/hud/tools/commonAlerts.js
@@ -155,7 +155,7 @@ var CommonAlerts = (function() {
 										var alert = pageAlerts[alertRisk][alertName][i];
 										if (alert.param.length > 0 && ! reportedParams.has(alert.param)) {
 											reportedParams.add(alert.param);
-											utils.messageFrame2(event.detail.tabId, "management", {
+											utils.messageFrame(event.detail.tabId, "management", {
 												action: "commonAlerts.alert",
 												name: alert.name,
 												id: alert.id,

--- a/src/main/zapHomeFiles/hud/tools/history.js
+++ b/src/main/zapHomeFiles/hud/tools/history.js
@@ -37,7 +37,7 @@ var History = (function() {
 		config.toolLabel = LABEL;
 		config.options = {remove: I18n.t("common_remove")};
 
-		utils.messageFrame2(tabId, "display", {action:"showButtonOptions", config:config})
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {
@@ -82,7 +82,7 @@ var History = (function() {
 			config.activeTab = data.activeTab;
 		}
 
-		return utils.messageFrame2(tabId, "display", {action:"showHistoryMessage", config:config})
+		return utils.messageFrame(tabId, "display", {action:"showHistoryMessage", config:config})
 			.then(data => {
 				// Handle button choice
 				if (data.buttonSelected === "replay") {

--- a/src/main/zapHomeFiles/hud/tools/htmlReport.js
+++ b/src/main/zapHomeFiles/hud/tools/htmlReport.js
@@ -32,7 +32,7 @@ var HtmlReport = (function() {
 		config.toolLabel = LABEL;
 		config.options = {remove: I18n.t("common_remove")};
 
-		utils.messageFrame2(tabId, "display", {action:"showButtonOptions", config:config})
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {
@@ -43,7 +43,7 @@ var HtmlReport = (function() {
 	}
 
 	function showHtmlReport(tabId) {
-		utils.messageFrame2(tabId, "display", {action:"showHtmlReport"})
+		utils.messageFrame(tabId, "display", {action:"showHtmlReport"})
 			.catch(utils.errorHandler);
 	}
 

--- a/src/main/zapHomeFiles/hud/tools/hudErrors.js
+++ b/src/main/zapHomeFiles/hud/tools/hudErrors.js
@@ -27,7 +27,7 @@ var HudErrors = (function() {
 		tool.position = 0;
 		tool.count = 0;
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 	function showDialog(tabId) {
@@ -50,7 +50,7 @@ var HudErrors = (function() {
 							tool.records = [];
 							tool.icon = ICONS.NONE;
 							utils.messageAllTabs(tool.panel, {action: 'broadcastUpdate', tool: {name: NAME, data: tool.data, icon: ICONS.NONE, label: tool.label}});
-							utils.saveTool(tool);
+							utils.writeTool(tool);
 						}
 						else {
 							//cancel

--- a/src/main/zapHomeFiles/hud/tools/hudErrors.js
+++ b/src/main/zapHomeFiles/hud/tools/hudErrors.js
@@ -41,7 +41,7 @@ var HudErrors = (function() {
 					{text:I18n.t("common_clear"), id:"clear"}
 				];
 
-				utils.messageFrame2(tabId, "display", {action:"showDialog", config:config})
+				utils.messageFrame(tabId, "display", {action:"showDialog", config:config})
 					.then(response => {
 
 						// Handle button choice
@@ -75,7 +75,7 @@ var HudErrors = (function() {
 		config.toolLabel = LABEL;
 		config.options = {remove: I18n.t("common_remove")};
 
-		utils.messageFrame2(tabId, "display", {action:"showButtonOptions", config:config})
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {

--- a/src/main/zapHomeFiles/hud/tools/pageAlertsHigh.js
+++ b/src/main/zapHomeFiles/hud/tools/pageAlertsHigh.js
@@ -32,7 +32,7 @@ var PageAlertsHigh = (function() {
 		tool.alerts = {};
 		tool.cache = {};
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 	function showAlerts(tabId, url) {

--- a/src/main/zapHomeFiles/hud/tools/pageAlertsInformational.js
+++ b/src/main/zapHomeFiles/hud/tools/pageAlertsInformational.js
@@ -32,7 +32,7 @@ var PageAlertsInformational = (function() {
 		tool.alerts = {};
 		tool.cache = {};
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 	function showAlerts(tabId, url) {

--- a/src/main/zapHomeFiles/hud/tools/pageAlertsLow.js
+++ b/src/main/zapHomeFiles/hud/tools/pageAlertsLow.js
@@ -32,7 +32,7 @@ var PageAlertsLow = (function() {
 		tool.alerts = {};
 		tool.cache = {};
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 	function showAlerts(tabId, url) {

--- a/src/main/zapHomeFiles/hud/tools/pageAlertsMedium.js
+++ b/src/main/zapHomeFiles/hud/tools/pageAlertsMedium.js
@@ -32,7 +32,7 @@ var PageAlertsMedium = (function() {
 		tool.alerts = {};
 		tool.cache = {};
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 	function showAlerts(tabId, url) {

--- a/src/main/zapHomeFiles/hud/tools/scope.js
+++ b/src/main/zapHomeFiles/hud/tools/scope.js
@@ -62,7 +62,7 @@ var Scope = (function() {
 					];
 				}
 
-				utils.messageFrame2(tabId, "display", {action:"showDialog", config:config})
+				utils.messageFrame(tabId, "display", {action:"showDialog", config:config})
 					.then(response => {
 
 						// Handle button choice
@@ -147,7 +147,7 @@ var Scope = (function() {
 		config.toolLabel = LABEL;
 		config.options = {remove: I18n.t("common_remove")};
 
-		utils.messageFrame2(tabId, "display", {action:"showButtonOptions", config:config})
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {

--- a/src/main/zapHomeFiles/hud/tools/showEnable.js
+++ b/src/main/zapHomeFiles/hud/tools/showEnable.js
@@ -27,7 +27,7 @@ var ShowEnable = (function() {
 		tool.position = 0;
 		tool.count = 0;
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 

--- a/src/main/zapHomeFiles/hud/tools/showEnable.js
+++ b/src/main/zapHomeFiles/hud/tools/showEnable.js
@@ -87,7 +87,7 @@ var ShowEnable = (function() {
 				tool.data = count;
 
 				utils.writeTool(tool);
-				utils.messageFrame2(tabId, tool.panel, {action: 'updateData', tool: {name: NAME, data: count}})
+				utils.messageFrame(tabId, tool.panel, {action: 'updateData', tool: {name: NAME, data: count}})
 			})
 			.catch(utils.errorHandler);
 	}
@@ -99,7 +99,7 @@ var ShowEnable = (function() {
 		config.toolLabel = LABEL;
 		config.options = {remove: I18n.t("common_remove")};
 
-		utils.messageFrame2(tabId, "display", {action:"showButtonOptions", config:config})
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {
@@ -121,13 +121,13 @@ var ShowEnable = (function() {
 			.then(tool => {
 				if (tool.isRunning) {
 					port.postMessage({label: LABEL, data: 0, icon: ICONS.ON})
-					utils.messageFrame2(tabId, "management", {action: 'showEnable.on'})
+					utils.messageFrame(tabId, "management", {action: 'showEnable.on'})
 				}
 				else {
 					port.postMessage({label: LABEL, data: 0, icon: ICONS.OFF})
 				}
 
-				utils.messageFrame2(tabId, "management", {action:"showEnable.count"});
+				utils.messageFrame(tabId, "management", {action:"showEnable.count"});
 			})
 			.catch(utils.errorHandler)
 	}

--- a/src/main/zapHomeFiles/hud/tools/siteAlertsHigh.js
+++ b/src/main/zapHomeFiles/hud/tools/siteAlertsHigh.js
@@ -32,7 +32,7 @@ var SiteAlertsHigh = (function() {
 		tool.alerts = {};
 		tool.cache = {};
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 	function showAlerts(tabId, domain) {

--- a/src/main/zapHomeFiles/hud/tools/siteAlertsInformational.js
+++ b/src/main/zapHomeFiles/hud/tools/siteAlertsInformational.js
@@ -32,7 +32,7 @@ var SiteAlertsInformational = (function() {
 		tool.alerts = {};
 		tool.cache = {};
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 	function showAlerts(tabId, domain) {

--- a/src/main/zapHomeFiles/hud/tools/siteAlertsLow.js
+++ b/src/main/zapHomeFiles/hud/tools/siteAlertsLow.js
@@ -32,7 +32,7 @@ var SiteAlertsLow = (function() {
 		tool.alerts = {};
 		tool.cache = {};
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 	function showAlerts(tabId, domain) {

--- a/src/main/zapHomeFiles/hud/tools/siteAlertsMedium.js
+++ b/src/main/zapHomeFiles/hud/tools/siteAlertsMedium.js
@@ -32,7 +32,7 @@ var SiteAlertsMedium = (function() {
 		tool.alerts = {};
 		tool.cache = {};
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 	function showAlerts(tabId, domain) {

--- a/src/main/zapHomeFiles/hud/tools/siteTree.js
+++ b/src/main/zapHomeFiles/hud/tools/siteTree.js
@@ -27,7 +27,7 @@ var SiteTree = (function() {
 		tool.position = 0;
 		tool.urls = [];
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 	}
 
 	function showSiteTree(tabId) {

--- a/src/main/zapHomeFiles/hud/tools/siteTree.js
+++ b/src/main/zapHomeFiles/hud/tools/siteTree.js
@@ -31,7 +31,7 @@ var SiteTree = (function() {
 	}
 
 	function showSiteTree(tabId) {
-		utils.messageFrame2(tabId, "display", {action:"showSiteTree"})
+		utils.messageFrame(tabId, "display", {action:"showSiteTree"})
 			.catch(utils.errorHandler);
 	}
 
@@ -42,7 +42,7 @@ var SiteTree = (function() {
 		config.toolLabel = LABEL;
 		config.options = {remove: I18n.t("common_remove")};
 
-		utils.messageFrame2(tabId, "display", {action:"showButtonOptions", config:config})
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {

--- a/src/main/zapHomeFiles/hud/tools/spider.js
+++ b/src/main/zapHomeFiles/hud/tools/spider.js
@@ -64,7 +64,7 @@ var Spider = (function() {
 
 				return config;
 			})
-			.then(config => utils.messageFrame2(tabId, "display", {action:"showDialog", config:config}))
+			.then(config => utils.messageFrame(tabId, "display", {action:"showDialog", config:config}))
 			.then(response => {
 				// Handle button choice
 				if (response.id === "start") {
@@ -101,7 +101,7 @@ var Spider = (function() {
 
 				utils.writeTool(tool);
 				utils.messageAllTabs(tool.panel, {action: 'broadcastUpdate', context: {notTabId: tabId}, tool: {name: NAME, label: LABEL, data: DATA.START, icon: ICONS.SPIDER}, isToolDisabled: true})
-				utils.messageFrame2(tabId, tool.panel, {action: 'updateData', tool: {name: NAME, label: LABEL, data: tool.data, icon: ICONS.SPIDER}});
+				utils.messageFrame(tabId, tool.panel, {action: 'updateData', tool: {name: NAME, label: LABEL, data: tool.data, icon: ICONS.SPIDER}});
 			})
 			.catch(utils.errorHandler);
 	}
@@ -141,7 +141,7 @@ var Spider = (function() {
 						tool.data = progress;
 
 						utils.writeTool(tool);
-						utils.messageFrame2(tool.runningTabId, tool.panel, {action: 'updateData', tool: tool})
+						utils.messageFrame(tool.runningTabId, tool.panel, {action: 'updateData', tool: tool})
 					}
 				})
 				.catch(utils.errorHandler);
@@ -171,7 +171,7 @@ var Spider = (function() {
 		config.toolLabel = LABEL;
 		config.options = {remove: I18n.t("common_remove")};
 
-		utils.messageFrame2(tabId, "display", {action:"showButtonOptions", config:config})
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {

--- a/src/main/zapHomeFiles/hud/tools/spider.js
+++ b/src/main/zapHomeFiles/hud/tools/spider.js
@@ -33,7 +33,7 @@ var Spider = (function() {
 		tool.isRunning = false;
 		tool.runningTabId = '';
 
-		utils.saveTool(tool);
+		utils.writeTool(tool);
 		registerForZapEvents("org.zaproxy.zap.extension.spider.SpiderEventPublisher");
 	}
 

--- a/src/main/zapHomeFiles/hud/tools/utils/alertUtils.js
+++ b/src/main/zapHomeFiles/hud/tools/utils/alertUtils.js
@@ -171,7 +171,7 @@ var alertUtils = (function() {
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {
-					utils.removeToolFromPanel(toolname);
+					utils.removeToolFromPanel(tabId, toolname);
 				}
 				else {
 					//cancel

--- a/src/main/zapHomeFiles/hud/tools/utils/alertUtils.js
+++ b/src/main/zapHomeFiles/hud/tools/utils/alertUtils.js
@@ -160,15 +160,6 @@ var alertUtils = (function() {
 			.catch(utils.errorHandler);
 	}
 	
-	function updateAlertCount(toolname, count) {
-		utils.loadTool(toolname)
-			.then(tool => {
-				tool.data = count;
-				return utils.saveTool(tool);
-			})
-			.catch(utils.errorHandler);
-	}
-
 	function showOptions(tabId, toolname, toolLabel) {
 		var config = {};
 
@@ -195,7 +186,6 @@ var alertUtils = (function() {
 		showPageAlerts: showPageAlerts,
 		showAlertDetails: showAlertDetails,
 		showOptions: showOptions,
-		updateAlertCount: updateAlertCount,
 		flattenAllAlerts: flattenAllAlerts,
 		setPageAlerts: setPageAlerts
 	};

--- a/src/main/zapHomeFiles/hud/tools/utils/alertUtils.js
+++ b/src/main/zapHomeFiles/hud/tools/utils/alertUtils.js
@@ -17,7 +17,7 @@ var alertUtils = (function() {
 			.then(json => {
 				config.alerts = flattenAllAlerts(json);
 				
-				utils.messageFrame2(tabId, "display", {action: "showAllAlerts", config:config}).then(response => {
+				utils.messageFrame(tabId, "display", {action: "showAllAlerts", config:config}).then(response => {
 					// Handle button choice
 					if (response.alertId) {
 						let backFunction = function() {showSiteAlerts(tabId, title, target, alertRisk)};
@@ -78,7 +78,7 @@ var alertUtils = (function() {
 			.then(json => {
 				config.alerts = flattenAllAlerts(json);
 				
-				return utils.messageFrame2(tabId, "display", {action: "showAllAlerts", config:config})
+				return utils.messageFrame(tabId, "display", {action: "showAllAlerts", config:config})
 			})
 			.then(response => {
 				// Handle button choice
@@ -103,7 +103,7 @@ var alertUtils = (function() {
 						config.title = json.alert.alert;
 						config.details = json.alert;
 
-						utils.messageFrame2(tabId, "display", {action: "showAlertDetails", config: config})
+						utils.messageFrame(tabId, "display", {action: "showAlertDetails", config: config})
 							.then(response => {
 								if (response.back) {
 									backFunction();
@@ -167,7 +167,7 @@ var alertUtils = (function() {
 		config.toolLabel = toolLabel;
 		config.options = {remove: I18n.t("common_remove")};
 
-		utils.messageFrame2(tabId, "display", {action:"showButtonOptions", config:config})
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
 			.then(response => {
 				// Handle button choice
 				if (response.id == "remove") {

--- a/src/main/zapHomeFiles/hud/utils.js
+++ b/src/main/zapHomeFiles/hud/utils.js
@@ -175,85 +175,31 @@ var utils = (function() {
 	 * Initialize all of the info that will be stored in indexeddb.
 	 */
 	function configureStorage() {
-		var promises = [];
+		let promises = [];
 	
 		promises.push(localforage.setItem(IS_HUD_CONFIGURED, true));
 		promises.push(localforage.setItem(IS_FIRST_TIME, true));
 		promises.push(localforage.setItem(IS_SERVICEWORKER_REFRESHED, false))
 		promises.push(localforage.setItem('upgradedDomains', {}))
-	
-		promises.push(loadFrame("rightPanel").then(oldPanel => {
-			var panel = {};
-	
-			panel.key = "rightPanel";
-			panel.orientation = "right";
-			panel.tools = [];
-			if (oldPanel) {
-				panel.clientId = oldPanel.clientId;
-			}
-	
-			return saveFrame(panel);
-		}));
-	
-		promises.push(loadFrame("leftPanel").then(oldPanel => {
-			var panel = {};
-	
-			panel.key = "leftPanel";
-			panel.orientation = "left";
-			panel.tools = [];
-			if (oldPanel) {
-				panel.clientId = oldPanel.clientId;
-			}
-	
-			return saveFrame(panel);
-		}));
-		
-		promises.push(loadFrame("display").then(oldFrame => {
-			var frame = {};
-	
-			frame.key = "display";
-			if (oldFrame) {
-				frame.clientId = oldFrame.clientId;
-			}
-	
-			return saveFrame(frame);
-		}));
-	
-		promises.push(loadFrame("management").then(oldFrame => {
-			var frame = {};
-	
-			frame.key = "management";
-			if (oldFrame) {
-				frame.clientId = oldFrame.clientId;
-			}
-	
-			return saveFrame(frame);
-		}));
-	
-		promises.push(loadFrame("growlerAlerts").then(oldFrame => {
-			var frame = {};
-	
-			frame.key = "growlerAlerts";
-			if (oldFrame) {
-				frame.clientId = oldFrame.clientId;
-			}
-	
-			return saveFrame(frame);
-		}));
-	
-		promises.push(loadFrame('drawer').then(oldFrame => {
-			var frame = {};
-	
-			frame.key = "drawer";
-			if (oldFrame) {
-				frame.clientId = oldFrame.clientId;
-			}
-	
-			return saveFrame(frame);
-		}));
-	
+
 		// set other values to defaults on startup
 		promises.push(initDefaults());
+
+		let leftPanel = {
+			key: 'leftPanel',
+			orientation: 'left',
+			tools: []
+		};
+	
+		promises.push(saveFrame(leftPanel));
+
+		let rightPanel = {
+			key: 'rightPanel',
+			orientation: 'right',
+			tools: []
+		};
+	
+		promises.push(saveFrame(rightPanel));
 	
 		return Promise.all(promises)
 			.catch(errorHandler);

--- a/src/main/zapHomeFiles/hud/utils.js
+++ b/src/main/zapHomeFiles/hud/utils.js
@@ -329,41 +329,21 @@ var utils = (function() {
 	}
 	
 	/* 
-	 * loads the tool blob from indexeddb using the tool's name
+	 * Loads the tool blob from indexeddb using the tool's name as the key.
 	 */
 	function loadTool(name) {
 		log(LOG_TRACE, 'utils.loadTool', name);
 		return localforage.getItem(name);
 	}
-	
+
+	/* 
+	 * Writes the tool blob to indexeddb using the tool's name as the key.
+	 */
 	function writeTool(tool) {
 		log(LOG_TRACE, 'utils.writeTool', tool.name);
 		return localforage.setItem(tool.name, tool);
 	}
-	
-	/* 
-	 * saves the tool blob to indexeddb
-	 */
-	function saveTool(tool) {
-		log(LOG_TRACE, 'utils.saveTool', tool.name);
-		return localforage.setItem(tool.name, tool)
-			.then(tool => {
-				// Notify Panel of Updated Data
-				if (tool.isSelected) {
-					messageFrame(tool.panel, {action:"updateData", tool:tool})
-						.catch(err => {
-							// this is only catching the NoClientIdError which occurs 
-							// when tools are added on startup and the panels haven't 
-							// been added yet
-							log(LOG_WARN, "messageFrame", "NoClientIdError - panel: " + tool.panel + " not yet available to be messaged", err);
-						});
-				}
-	
-				return tool;
-			})
-			.catch(errorHandler);
-	}
-	
+
 	/*
 	 * Return all tools currently selected in a panel.
 	 */
@@ -490,21 +470,6 @@ var utils = (function() {
 	/*
 	 * Send a postMessage to an iframe window using the custom stored frame key in indexdb.
 	 */
-	function messageFrame(key, message) {
-		return loadFrame(key)
-				.then(getWindowFromFrame)
-				.then(window => messageWindow(window, message))
-				.catch(err => {
-					// this catches all errors, unless it is a NoClientIdError
-					if (err instanceof NoClientIdError) {
-						throw err;
-					}
-					else {
-						errorHandler(err);
-					}
-				});
-	}
-	
 	function messageFrame2(tabId, frameId, message) {
 		return clients.matchAll({includeUncontrolled: true})
 			.then(clients => {
@@ -711,11 +676,6 @@ var utils = (function() {
 			.catch(errorHandler)
 	}
 	
-	// todo: maybe needed instead of passing info through postmessage
-	function getTargetDomain() {
-		return messageFrame("management", {action:"getTargetDomain"});
-	}
-	
 	/*
 	 * Log an error in a human readable way with a stack trace.
 	 */
@@ -804,12 +764,10 @@ return {
 		registerTools: registerTools,
 		loadTool: loadTool,
 		writeTool: writeTool,
-		saveTool: saveTool,
 		loadPanelTools: loadPanelTools,
 		loadAllTools: loadAllTools,
 		addToolToPanel: addToolToPanel,
 		removeToolFromPanel: removeToolFromPanel,
-		messageFrame: messageFrame,
 		messageFrame2: messageFrame2,
 		messageAllTabs: messageAllTabs,
 		getAllClients: getAllClients,
@@ -818,7 +776,6 @@ return {
 		sortToolsByPosition: sortToolsByPosition,
 		configureButtonHtml: configureButtonHtml,
 		getUpgradedDomain: getUpgradedDomain,
-		getTargetDomain: getTargetDomain,
 		errorHandler: errorHandler,
 		getZapFilePath: getZapFilePath,
 		getZapImagePath: getZapImagePath,

--- a/src/main/zapHomeFiles/hud/utils.js
+++ b/src/main/zapHomeFiles/hud/utils.js
@@ -470,7 +470,7 @@ var utils = (function() {
 	/*
 	 * Send a postMessage to an iframe window using the custom stored frame key in indexdb.
 	 */
-	function messageFrame2(tabId, frameId, message) {
+	function messageFrame(tabId, frameId, message) {
 		return clients.matchAll({includeUncontrolled: true})
 			.then(clients => {
 				for (let i = 0; i < clients.length; i++) {
@@ -768,7 +768,7 @@ return {
 		loadAllTools: loadAllTools,
 		addToolToPanel: addToolToPanel,
 		removeToolFromPanel: removeToolFromPanel,
-		messageFrame2: messageFrame2,
+		messageFrame: messageFrame,
 		messageAllTabs: messageAllTabs,
 		getAllClients: getAllClients,
 		getWindowVisibilityState: getWindowVisibilityState,


### PR DESCRIPTION
This PR works on cleaning up some remaining todos from #234 MultiTab support:

- [x] remove old `messageFrame` function and switch to only `messageFrame2` function (and then rename)
- [x] find and change all `saveTool` calls to `writeTool`
- [x] remove tracking the clients in the serviceworker

Also fixes a bug in removing alert tools from panels.