### PR TITLE
Better TabId

### DIFF
--- a/src/main/zapHomeFiles/hud/target/inject.js
+++ b/src/main/zapHomeFiles/hud/target/inject.js
@@ -20,6 +20,14 @@
 		);
 	}
 
+	function generateTabId() {
+		let millis = new Date().getTime();
+		let r = Math.floor(Math.random()*1000);
+		let tabId = '' + millis + '-' + r;
+
+		return tabId.substring(6);
+	}
+
 	/* TARGET INTERACTIONS */
 	// code that will interact with the target domain will go here
 
@@ -352,7 +360,7 @@
 
 	/* initializes the HUD Frames */
 	if (window.top == window.self) {
-		tabId = Math.round(Math.random()*5000); //todo: nonsense random number generator;
+		tabId = generateTabId();
 
 		window.addEventListener("message", receiveMessages);
 


### PR DESCRIPTION
Changed the tabId to be combination of timestamp and random number to prevent the offchance that tabIds would collide.

The tabId format is now `MMMMMMM-RRR` where `MMMMMMM` is the last 7 digits of the timestamp in milliseconds and `RRR` is a random 3 digit number. 