### PR TITLE
Add new Web Sockets tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
  - Add css transitions to tool buttons so that they slide out when hovered over.
+ - Initial support for WebSockets - this adds a new lower tab that shows all of the WebSocket messages proxied through ZAP 
 
 ## [0.3.0] - 2019-02-11
  - Many thanks to Matt Austin (@mattaustin) for reporting security vulnerabilities with the HUD and working with us to fix them.

--- a/src/main/zapHomeFiles/hud/drawer.css
+++ b/src/main/zapHomeFiles/hud/drawer.css
@@ -2,7 +2,7 @@
   padding:0; /*Override Spectre table cell padding*/
 }
 
-#history-header{
+.drawer-header{
   position:sticky;
   top:0;
   right:0;
@@ -11,30 +11,30 @@
   font-size: .8em;
 }
 
-#history-header tr{
+.drawer-header tr{
   text-align: center;
 }
 
-#history-filter{
+.drawer-filter{
   border-color: none;
 }
 
-#history-filter.error{
+.drawer-filter.error{
   border-color: rgb(252, 130, 130);
   background-color: rgb(248, 230, 230);
 }
 
-#history-messages{
+.drawer-messages{
   font-size: .7em;
   padding: 0 1%;
   margin-bottom: 1%;
 }
 
-#history-messages .message-tr{
+.drawer-messages .message-tr{
 
 }
 
-#history-messages .message-tr td{
+.drawer-messages .message-tr td{
   padding: 0 5px;
 }
 
@@ -55,6 +55,22 @@
 
 .table .field.url, .table .title.url{
   width: 75px;
+}
+
+.table .field.direction, .table .title.direction{
+  width: 125px;
+}
+
+.table .field.opcode, .table .title.opcode{
+  width: 125px;
+}
+
+.table .field.length, .table .title.length{
+  width: 95px;
+}
+
+.table .field.payload, .table .title.payload{
+  width: 150px;
 }
 
 .table .title.filter{

--- a/src/main/zapHomeFiles/hud/drawer.html
+++ b/src/main/zapHomeFiles/hud/drawer.html
@@ -17,12 +17,15 @@
             <tab :name="$t('message.history_tool')">
                 <history></history>
             </tab>
+            <tab :name="$t('message.websockets_tool')">
+                <websockets></websockets>
+            </tab>
         </tabs>
     </div>
 
     <template id="history-template">
         <div>
-            <table id="history-header" class="table">
+            <table id="history-header" class="table drawer-header">
                 <thead>
                     <tr>
                         <th class="title time"> 
@@ -39,7 +42,7 @@
                         </th>
                         <th class="title filter"> 
                             <span>
-                                <input id="history-filter" v-model="filter" type="text" v-bind:class="{ 'error': isRegExError }" placeholder="Filter" />
+                                <input id="history-filter" class="drawer-filter" v-model="filter" type="text" v-bind:class="{ 'error': isRegExError }" placeholder="Filter" />
                             </span>
                             <span>
                                 <input v-model="regexEnabled" type="checkbox" />
@@ -54,13 +57,65 @@
                     </tr>
                 </thead>
             </table>
-            <table id="history-messages" class="table table-striped table-hover table-scroll table-history" style="min-width: fit-content;">
+            <table id="history-messages" class="table table-striped table-hover table-scroll table-history drawer-messages" style="min-width: fit-content;">
                 <tbody>
                     <tr v-for="message in filteredMessages" @click="messageSelected(message.id)" :id="'message-tr-'+message.id" class="message-tr">
                         <td class="field time"> {{ message.time }} </td>
                         <td class="field code"> {{ message.code }} </td>
                         <td class="field method"> {{ message.method }} </td>
                         <td class="field url"> {{ message.url }} </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </template>
+
+
+    <template id="websockets-template">
+        <div>
+            <table id="websockets-header" class="table drawer-header">
+                <thead>
+                    <tr>
+                        <th class="title time"> 
+                            {{ $t('message.websockets_message_field_time') }}
+                        </th>
+                        <th class="title direction"> 
+                            {{ $t('message.websockets_message_field_direction') }}
+                        </th>
+                        <th class="title opcode"> 
+                            {{ $t('message.websockets_message_field_opcode') }}
+                        </th>
+                        <th class="title length"> 
+                            {{ $t('message.websockets_message_field_bytes') }}
+                        </th>
+                        <th class="title payload"> 
+                            {{ $t('message.websockets_message_field_payload') }}
+                        </th>
+                        <th class="title filter"> 
+                            <span>
+                                <input id="websockets-filter" class="drawer-filter" v-model="filter" type="text" v-bind:class="{ 'error': isRegExError }" placeholder="Filter" />
+                            </span>
+                            <span>
+                                <input v-model="regexEnabled" type="checkbox" />
+                            </span>
+                            <span>
+                                {{ enableRegExText }}
+                            </span>
+                        </th>
+                        <th class="title hidden">
+                            <span>{{ websocketsItemsFilteredMessage }}</span>
+                        </th>
+                    </tr>
+                </thead>
+            </table>
+            <table id="websockets-messages" class="table table-striped table-hover table-scroll table-history drawer-messages" style="min-width: fit-content;">
+                <tbody>
+                    <tr v-for="message in filteredMessages" @click="messageSelected(message.id)" :id="'message-tr-'+message.id" class="message-tr">
+                        <td class="field time"> {{ message.time }} </td>
+                        <td class="field direction"> {{ message.direction }} </td>
+                        <td class="field opcode"> {{ message.opCode }} </td>
+                        <td class="field length"> {{ message.length }} </td>
+                        <td class="field payload"> {{ message.messageSummary }} </td>
                     </tr>
                 </tbody>
             </table>

--- a/src/main/zapHomeFiles/hud/drawer.js
+++ b/src/main/zapHomeFiles/hud/drawer.js
@@ -18,7 +18,7 @@ Vue.component('history', {
             hiddenMessageCount: 0,
             isRegExError: false,
             historyItemsFilteredMessage: '',
-            enableRegExText: I18n.t("history_enable_regex")
+            enableRegExText: I18n.t("common_enable_regex")
         }
     },
     computed: {
@@ -62,7 +62,7 @@ Vue.component('history', {
             navigator.serviceWorker.controller.postMessage({tabId: tabId, frameId: frameId, action: "showHttpMessageDetails", tool: "history", id:id});
         },
         historyItemsFiltered() {
-            this.historyItemsFilteredMessage = I18n.t("history_items_filtered", [this.hiddenMessageCount, this.messageCount]);
+            this.historyItemsFilteredMessage = I18n.t("common_items_filtered", [this.hiddenMessageCount, this.messageCount]);
         }
     },
     watch: {
@@ -89,6 +89,112 @@ Vue.component('history', {
         })
 
 		eventBus.$on('updateMessages', data => {
+            this.messages = this.messages.concat(data.messages);
+
+            let count = data.messages.length;
+            this.$parent.$emit('badgeDataEvent', {data: count})
+        });
+
+    },
+    updated() {
+        if (this.messages.length > 0) {
+            let lastMessage = this.messages[this.messages.length - 1]
+            let lastid = 'message-tr-' + lastMessage.id
+            let lastIdElem = document.querySelector(lastid);
+            if(lastIdElem){
+                lastIdElem.scrollIntoView({block:'end', behavior:'smooth'});
+            }
+            
+            //move horizontal scroll bar to the left
+            let tabsDetailsElems = document.querySelectorAll('tabs-details');
+            if (tabsDetailsElems.length > 0){
+                tabsDetails[0].scrollTo(0, tabsDetails.scrollHeight);
+            }
+        }
+    }
+});
+
+Vue.component('websockets', {
+    template: '#websockets-template',
+    data() {
+        return {
+            filter: '',
+            regexEnabled: false,
+            messages: [],
+            hiddenMessageCount: 0,
+            isRegExError: false,
+            websocketsItemsFilteredMessage: '',
+            enableRegExText: I18n.t("common_enable_regex")
+        }
+    },
+    computed: {
+        timeDescendingMessages() {
+            return this.messages.slice().reverse();
+        },
+        messageCount() {
+            return this.messages.length;
+        },
+        filteredMessages() {
+            const self=this,
+                  isRegex = this.regexEnabled;
+            let re;
+
+            if (isRegex){
+                try {
+                    re = new RegExp(this.filter);
+                    this.isRegExError = false;
+                }
+                catch (ex) {
+                    this.isRegExError = true;
+                    return []; //Return empty array if invalid RegEx
+                }
+            }
+
+            return this.messages.filter( message => {
+                if (self.filter.trim().length === 0) {
+                    return true;
+                }
+                if (isRegex){
+                    return re.test(message.messageSummary);
+                }
+                else{
+                    return message.messageSummary.indexOf(self.filter)>=0; 
+                }
+            });
+        }
+    },
+    methods: {
+        messageSelected(id) {
+            navigator.serviceWorker.controller.postMessage({tabId: tabId, frameId: frameId, action: "showWebSocketMessageDetails", tool: "websockets", id:id});
+        },
+        websocketsItemsFiltered() {
+            this.websocketsItemsFilteredMessage = I18n.t("common_items_filtered", [this.hiddenMessageCount, this.messageCount]);
+        }
+    },
+    watch: {
+        regexEnabled() {
+           this.isRegExError = !this.regexEnabled ? false : this.isRegExError;
+        },
+        filteredMessages() {
+            this.$nextTick(function () {
+                const visibleMessages = document.querySelectorAll("#websockets-messages .message-tr");
+                this.hiddenMessageCount = (!this.messages) ? 0 : this.messages.length - visibleMessages.length;
+                this.websocketsItemsFiltered();
+            });
+        }
+    },
+    created() {
+        utils.loadTool('websockets')
+            .then(tool => {
+                this.messages = tool.messages
+            })
+            .catch(utils.errorHandler)
+
+        eventBus.$on('setMessages', data => {
+            this.messages = data.messages;
+        })
+
+		eventBus.$on('updateWebSockets', data => {
             this.messages = this.messages.concat(data.messages);
 
             let count = data.messages.length;
@@ -159,6 +265,9 @@ Vue.component('tabs', {
         highlightTab(href) {
             this.tabs.forEach(tab => {
                 tab.isActive = (tab.href == href);
+                if (tab.isActive) {
+                	tab.badgeData = 0;
+                }
             });
         }
     },
@@ -215,7 +324,7 @@ Vue.component('tab', {
         let self = this;
 
         this.$on('badgeDataEvent', message => {
-            if (!self.$parent.isOpen) {
+            if (!self.$parent.isOpen || ! self.isActive) {
                 self.badgeData += message.data;
             }
         })
@@ -314,6 +423,13 @@ navigator.serviceWorker.addEventListener('message', event => {
 	switch(action) {
         case 'updateMessages':
             eventBus.$emit('updateMessages', {
+                messages: event.data.messages,
+				port: port
+			});
+			
+            break;
+        case 'updateWebSockets':
+            eventBus.$emit('updateWebSockets', {
                 messages: event.data.messages,
 				port: port
 			});

--- a/src/main/zapHomeFiles/hud/tools/history.js
+++ b/src/main/zapHomeFiles/hud/tools/history.js
@@ -55,7 +55,7 @@ var History = (function() {
 
 	function showHttpMessageDetails(tabId, data) {
 		if (!data) {
-			throw new Error('Coud not load HTTP message details')
+			throw new Error('Could not load HTTP message details')
 		}
 
 		var parsedReqData = utils.parseRequestHeader(data.requestHeader);

--- a/src/main/zapHomeFiles/hud/tools/websockets.js
+++ b/src/main/zapHomeFiles/hud/tools/websockets.js
@@ -1,0 +1,127 @@
+/*
+ * WebSockets Tool
+ *
+ * Displays websocket messages in a tab at the bottom of the screen.
+ */
+
+var WebSockets = (function() {
+
+	// Constants
+	var NAME = "websockets";
+	var LABEL = I18n.t("websockets_tool");
+	var ICONS = {};
+		ICONS.CLOCK = "clock.png";	// Not actually shown anywhere, should be
+									// changed if it is going to be shown
+	var tool = {};
+
+	function initializeStorage() {
+		tool.name = NAME;
+		tool.label = LABEL;
+		tool.data = 0;
+		tool.icon = ICONS.CLOCK;
+		tool.isSelected = false;
+		tool.isHidden = true;
+		tool.panel = "";
+		tool.position = 0;
+		tool.messages = [];
+
+		utils.writeTool(tool);
+		registerForZapEvents("org.zaproxy.zap.extension.websocket.WebSocketEventPublisher");
+	}
+
+	function showOptions(tabId) {
+		var config = {};
+
+		config.tool = NAME;
+		config.toolLabel = LABEL;
+		config.options = {remove: I18n.t("common_remove")};
+
+		utils.messageFrame(tabId, "display", {action:"showButtonOptions", config:config})
+			.then(response => {
+				// Handle button choice
+				if (response.id == "remove") {
+					utils.removeToolFromPanel(tabId, NAME);
+				}
+			})
+			.catch(utils.errorHandler);
+	}
+	
+	self.addEventListener("org.zaproxy.zap.extension.websocket.WebSocketEventPublisher", event => {
+		var eventType = event.detail['event.type'];
+		
+		if (eventType == "ws.message") {
+			let message = {};
+			
+			let date = new Date(Number(event.detail.timeSentInMs));
+			let dateStr = date.getHours() + ':' + date.getMinutes() + ':' + date.getSeconds() + '.' + date.getMilliseconds();
+	
+			message.timeInMs = event.detail.timeSentInMs;
+			message.time = dateStr;
+			message.direction = event.detail.direction;
+			message.length = event.detail.length;
+			message.messageSummary = event.detail.messageSummary;
+			message.opCode = event.detail.opCode + '=' + event.detail.opCodeString;
+			message.id = event.detail.messageId;
+	
+			utils.messageAllTabs('drawer', {action: 'updateWebSockets', messages: [message]})
+				.catch(utils.errorHandler);
+	
+			tool.messages.push(message);
+			utils.writeTool(tool);
+		}
+	});
+
+	self.addEventListener("activate", event => {
+		initializeStorage();
+	});
+
+	function trimMessages(lastPageUnloadTime) {
+		utils.loadTool(NAME)
+			.then(tool => {
+				tool.messages = tool.messages.filter(message => message.timeInMs > lastPageUnloadTime)
+				utils.writeTool(tool)
+			})
+			.catch(utils.errorHandler);
+	}
+
+	self.addEventListener("message", event => {
+		var message = event.data;
+
+		// Broadcasts
+		switch(message.action) {
+			case "initializeTools":
+				initializeStorage();
+				break;
+			
+			case "unload":
+				trimMessages(message.time)
+				break;
+				
+			default:
+				break;
+		}
+
+		// Directed
+		if (message.tool === NAME) {
+			switch(message.action) {
+				case "buttonMenuCicked":
+					showOptions(message.tabId);
+					break;
+
+				case "showWebSocketMessageDetails":
+					// TODO
+					break;
+
+				default:
+					break;
+			}
+		}
+	});
+
+	return {
+		name: NAME,
+		initialize: initializeStorage
+	};
+})();
+
+self.tools[WebSockets.name] = WebSockets;

--- a/src/other/resources/UIMessages/UIMessages.properties
+++ b/src/other/resources/UIMessages/UIMessages.properties
@@ -47,7 +47,9 @@ break_tool = Break
 common_add = Add
 common_cancel = Cancel
 common_clear = Clear
+common_enable_regex = Enable RegEx
 common_in = In
+common_items_filtered = {0} of {1} items hidden by filters
 common_menu_title = Menu
 common_ok = OK
 common_on = On
@@ -74,8 +76,6 @@ history_http_message_title = HTTP Message
 history_replay_browser = Replay in Browser
 history_replay_console = Replay in Console
 history_tool = History
-history_enable_regex = Enable RegEx
-history_items_filtered = {0} of {1} items hidden by filters
 
 html_report_tool = Show HTML Report
 
@@ -103,3 +103,10 @@ spider_start = Start spidering this site?
 spider_start_scope = This site is not in scope.<br>In order to spider the site you must add it to the scope.<br>Add the site to the scope and start spidering it?
 spider_stop = The spider is currently running. Would you like to stop it?
 spider_tool = Spider
+
+websockets_message_field_time = Time
+websockets_message_field_direction = Direction
+websockets_message_field_opcode = Op Code
+websockets_message_field_bytes = Bytes
+websockets_message_field_payload = Payload
+websockets_tool = WebSockets


### PR DESCRIPTION
Depends on https://github.com/zaproxy/zap-extensions/pull/1926
Addresses the first checkbox on #373 ie just displaying the websocket messages
Its a rip off of the History tab, and filtering seems to work.
More testing is required ;)