### PR TITLE
Disable Safe Browsing in functional tests

### DIFF
--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/firefox/FirefoxUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/firefox/FirefoxUnitTest.java
@@ -40,6 +40,8 @@ public abstract class FirefoxUnitTest {
                 .setSslProxy(Constants.ZAP_HOST_PORT);
 
         this.firefoxOptions.addPreference("network.captive-portal-service.enabled", false);
+        this.firefoxOptions.addPreference("browser.safebrowsing.provider.mozilla.gethashURL", "");
+        this.firefoxOptions.addPreference("browser.safebrowsing.provider.mozilla.updateURL", "");
         this.firefoxOptions.addPreference("network.proxy.type", 1);
         this.firefoxOptions.addPreference("network.proxy.http", Constants.ZAP_HOST);
         this.firefoxOptions.addPreference("network.proxy.http_port", Constants.ZAP_PORT);


### PR DESCRIPTION
Tweak Firefox preferences to disable Safe Browsing, these just create
unwanted requests which might get in the way, by delaying the requests
from the actual tests.

Related to #344 - Make functional tests more reliable