### PR TITLE
Load latest upgraded domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Add tasks for Enable, Show and Break tutorial pages
  - Add plain text/regex filtering capability to History section [#286](https://github.com/zaproxy/zap-hud/issues/233)
 
+### Fixed
+ - Correct handling of upgraded domains on startup. [#162](https://github.com/zaproxy/zap-hud/issues/162)
+
 ## [0.2.0] - 2018-12-31
 
 ### Added

--- a/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -263,15 +263,23 @@ public class ExtensionHUD extends ExtensionAdaptor
     }
 
     public void addUpgradedHttpsDomain(URI uri) throws URIException {
-        this.upgradedHttpsDomains.add(uri.getHost() + ":" + uri.getPort());
+        this.upgradedHttpsDomains.add(getNormalisedDomain(uri));
+    }
+
+    static String getNormalisedDomain(URI uri) throws URIException {
+        int port = uri.getPort();
+        if (port == -1) {
+            return uri.getHost();
+        }
+        return uri.getHost() + ":" + uri.getPort();
     }
 
     public void removeUpgradedHttpsDomain(URI uri) throws URIException {
-        this.upgradedHttpsDomains.remove(uri.getHost() + ":" + uri.getPort());
+        this.upgradedHttpsDomains.remove(getNormalisedDomain(uri));
     }
 
     public boolean isUpgradedHttpsDomain(URI uri) throws URIException {
-        return this.upgradedHttpsDomains.contains(uri.getHost() + ":" + uri.getPort());
+        return this.upgradedHttpsDomains.contains(getNormalisedDomain(uri));
     }
 
     private void addScripts(File file, String prefix, ScriptType hudScriptType) {
@@ -382,9 +390,7 @@ public class ExtensionHUD extends ExtensionAdaptor
                     if (this.isUpgradedHttpsDomain(uri)) {
                         // Advise that we've upgraded this domain to https
                         Map<String, String> map = new HashMap<String, String>();
-                        map.put(
-                                HudEventPublisher.FIELD_DOMAIN,
-                                uri.getHost() + ":" + uri.getPort());
+                        map.put(HudEventPublisher.FIELD_DOMAIN, getNormalisedDomain(uri));
                         ZAP.getEventBus()
                                 .publishSyncEvent(
                                         HudEventPublisher.getPublisher(),
@@ -560,5 +566,9 @@ public class ExtensionHUD extends ExtensionAdaptor
 
     public HudAPI getAPI() {
         return this.api;
+    }
+
+    protected Set<String> getUpgradedHttpsDomains() {
+        return upgradedHttpsDomains;
     }
 }

--- a/src/main/java/org/zaproxy/zap/extension/hud/HttpUpgradeProxyListener.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HttpUpgradeProxyListener.java
@@ -101,7 +101,7 @@ public class HttpUpgradeProxyListener implements OverrideMessageProxyListener {
                         Map<String, String> map = new HashMap<String, String>();
                         map.put(
                                 HudEventPublisher.FIELD_DOMAIN,
-                                url.getHost() + ":" + url.getPort());
+                                ExtensionHUD.getNormalisedDomain(url));
                         ZAP.getEventBus()
                                 .publishSyncEvent(
                                         HudEventPublisher.getPublisher(),

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -89,6 +89,7 @@ public class HudAPI extends ApiImplementor {
     private static final String VIEW_GET_UI_OPTION = "getUiOption";
     private static final String VIEW_HUD_ALERT_DATA = "hudAlertData";
     private static final String VIEW_HEARTBEAT = "heartbeat";
+    private static final String VIEW_UPGRADED_DOMAINS = "upgradedDomains";
 
     private static final String PARAM_RECORD = "record";
     private static final String PARAM_HEADER = "header";
@@ -136,6 +137,7 @@ public class HudAPI extends ApiImplementor {
         this.addApiView(new ApiView(VIEW_HUD_ALERT_DATA, new String[] {PARAM_URL}));
         this.addApiView(new ApiView(VIEW_HEARTBEAT));
         this.addApiView(new ApiView(VIEW_GET_UI_OPTION, new String[] {PARAM_KEY}));
+        this.addApiView(new ApiView(VIEW_UPGRADED_DOMAINS));
 
         hudFileProxy = new HudFileProxy(this);
         hudFileUrl = API.getInstance().getCallBackUrl(hudFileProxy, API.API_URL_S);
@@ -296,6 +298,14 @@ public class HudAPI extends ApiImplementor {
                 String key = params.getString(PARAM_KEY);
                 validateKey(key);
                 return new ApiResponseElement(key, this.extension.getHudParam().getUiOption(key));
+            case VIEW_UPGRADED_DOMAINS:
+                ApiResponseList domains = new ApiResponseList(name);
+                extension
+                        .getUpgradedHttpsDomains()
+                        .forEach(
+                                domain ->
+                                        domains.addItem(new ApiResponseElement("domain", domain)));
+                return domains;
             default:
                 throw new ApiException(ApiException.Type.BAD_VIEW);
         }

--- a/src/main/zapHomeFiles/hud/serviceworker.js
+++ b/src/main/zapHomeFiles/hud/serviceworker.js
@@ -175,6 +175,17 @@ webSocket.onopen = function (event) {
 	// Basic test
 	webSocket.send('{ "component" : "core", "type" : "view", "name" : "version" }'); 
 	// Tools should register for alerts via the registerForWebSockerEvents function - see the break tool
+
+	apiCallWithResponse("hud", "view", "upgradedDomains")
+		.then(response => {
+			let upgradedDomains = {};
+
+			for (const domain of response.upgradedDomains) {
+				upgradedDomains[domain] = true;
+			}
+			return localforage.setItem('upgradedDomains', upgradedDomains);
+		})
+		.catch(utils.errorHandler);
 };
 
 webSocket.onmessage = function (event) {

--- a/src/main/zapHomeFiles/hud/utils.js
+++ b/src/main/zapHomeFiles/hud/utils.js
@@ -180,7 +180,6 @@ var utils = (function() {
 		promises.push(localforage.setItem(IS_HUD_CONFIGURED, true));
 		promises.push(localforage.setItem(IS_FIRST_TIME, true));
 		promises.push(localforage.setItem(IS_SERVICEWORKER_REFRESHED, false))
-		promises.push(localforage.setItem('upgradedDomains', {}))
 
 		// set other values to defaults on startup
 		promises.push(initDefaults());


### PR DESCRIPTION
Change the HUD (`serviceworker.js`) to load the upgraded domains from
ZAP after establishing the WebSocket connection to ensure the HUD knows
about them from the beginning, if not the HUD might miss the event that
notifies of the upgrade.
Remove (empty) initialisation of `upgradedDomains` in `utils.js` now
being done in `serviceworker.js`.
Extract a method in `ExtensionHUD` that normalises the upgraded domain.
Add a view to `HudAPI` that exposes the upgraded domains.
Update changelog.

Fix #162 - https upgrade bug on startup
Related to #344 - Make functional tests more reliable