### PR TITLE
Stop the tutorial server on unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  - Correct handling of upgraded domains on startup. [#162](https://github.com/zaproxy/zap-hud/issues/162)
+ - Stop the tutorial server when the add-on is uninstalled.
 
 ## [0.2.0] - 2018-12-31
 

--- a/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -189,6 +189,8 @@ public class ExtensionHUD extends ExtensionAdaptor
         getExtScript().removeListener(this);
 
         HudEventPublisher.unregister();
+
+        tutorialServer.stopServer();
     }
 
     @Override


### PR DESCRIPTION
Change ExtensionHUD to stop the server when unloaded, otherwise the
add-on is not properly uninstalled.
Update the changelog.