### PR TITLE
Change tests to run with multiple browsers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,7 +131,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:$jupiterVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$jupiterVersion")
 
-    testImplementation("io.github.bonigarcia:selenium-jupiter:2.2.0")
+    testImplementation("io.github.bonigarcia:selenium-jupiter:3.3.0")
     testImplementation("org.hamcrest:hamcrest-all:1.3")
     testImplementation("org.mockito:mockito-all:1.10.8")
     testImplementation(files(fileTree("lib").files))
@@ -247,12 +247,14 @@ tasks {
         args.set(listOf("-dev", "-config", "start.checkForUpdates=false", "-config", "hud.dir=$zapHome/hud") + hudDevArgs)
     }
 
+    register<Delete>("deleteTestHome") {
+        delete(testZapHome)
+    }
+
     register<CopyAddOn>("copyAddOnTestHome") {
         into(testZapHome.dir("plugin"))
 
-        doFirst {
-            delete(testZapHome)
-        }
+        dependsOn("deleteTestHome")
     }
 
     register<ZapStart>("zapStart") {

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/BrowsersTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/BrowsersTest.java
@@ -19,38 +19,52 @@
  */
 package org.zaproxy.zap.extension.hud.ui.browser;
 
-import io.github.bonigarcia.Options;
-import io.github.bonigarcia.SeleniumExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
+import io.github.bonigarcia.seljup.BrowserBuilder;
+import io.github.bonigarcia.seljup.Options;
+import io.github.bonigarcia.seljup.SeleniumExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.Proxy;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.remote.CapabilityType;
 import org.zaproxy.zap.extension.hud.ui.Constants;
 
-@ExtendWith({SeleniumExtension.class})
+@TestInstance(Lifecycle.PER_CLASS)
 public abstract class BrowsersTest {
-    @Options FirefoxOptions firefoxOptions;
 
-    public BrowsersTest() {
-        this.firefoxOptions = new FirefoxOptions();
+    private static final Proxy PROXY =
+            new Proxy()
+                    .setHttpProxy(Constants.ZAP_HOST_PORT)
+                    .setFtpProxy(Constants.ZAP_HOST_PORT)
+                    .setSslProxy(Constants.ZAP_HOST_PORT);
 
-        Proxy proxy = new Proxy();
-        proxy.setHttpProxy(Constants.ZAP_HOST_PORT)
-                .setFtpProxy(Constants.ZAP_HOST_PORT)
-                .setSslProxy(Constants.ZAP_HOST_PORT);
+    @Options
+    private static final FirefoxOptions FIREFOX_OPTIONS =
+            new FirefoxOptions()
+                    .setHeadless(true)
+                    .addPreference("network.captive-portal-service.enabled", false)
+                    .addPreference("browser.safebrowsing.provider.mozilla.gethashURL", "")
+                    .addPreference("browser.safebrowsing.provider.mozilla.updateURL", "")
+                    .addPreference("network.proxy.no_proxies_on", "")
+                    .addPreference("network.proxy.allow_hijacking_localhost", true)
+                    .setProxy(PROXY);
 
-        this.firefoxOptions.addPreference("network.captive-portal-service.enabled", false);
-        this.firefoxOptions.addPreference("browser.safebrowsing.provider.mozilla.gethashURL", "");
-        this.firefoxOptions.addPreference("browser.safebrowsing.provider.mozilla.updateURL", "");
-        this.firefoxOptions.addPreference("network.proxy.type", 1);
-        this.firefoxOptions.addPreference("network.proxy.http", Constants.ZAP_HOST);
-        this.firefoxOptions.addPreference("network.proxy.http_port", Constants.ZAP_PORT);
-        this.firefoxOptions.addPreference("network.proxy.ssl", Constants.ZAP_HOST);
-        this.firefoxOptions.addPreference("network.proxy.ssl_port", Constants.ZAP_PORT);
-        this.firefoxOptions.addPreference("network.proxy.share_proxy_settings", true);
-        this.firefoxOptions.addPreference("network.proxy.no_proxies_on", "");
-        this.firefoxOptions.addPreference("network.proxy.allow_hijacking_localhost", true);
-        firefoxOptions.setCapability(CapabilityType.PROXY, (Object) null);
-        firefoxOptions.setHeadless(true);
+    @Options
+    private static final ChromeOptions CHROME_OPTIONS =
+            new ChromeOptions()
+                    .setHeadless(true)
+                    .addArguments("--proxy-bypass-list=<-loopback>", "--window-size=1024,768")
+                    .setProxy(PROXY);
+
+    @RegisterExtension SeleniumExtension seleniumExtension = new SeleniumExtension();
+
+    @BeforeAll
+    void setup() {
+        seleniumExtension.addBrowsers(BrowserBuilder.firefox().build());
+        // TODO uncomment once the tests are more reliable
+        // https://github.com/zaproxy/zap-hud/issues/344
+        // seleniumExtension.addBrowsers(BrowserBuilder.chrome().build());
     }
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/TopSitesUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/TopSitesUnitTest.java
@@ -20,8 +20,8 @@
 package org.zaproxy.zap.extension.hud.ui.browser;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.openqa.selenium.firefox.FirefoxDriver;
+import org.junit.jupiter.api.TestTemplate;
+import org.openqa.selenium.WebDriver;
 import org.zaproxy.zap.extension.hud.ui.generic.GenericUnitTest;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
@@ -29,7 +29,7 @@ import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 /** Alexa top sites */
 public class TopSitesUnitTest extends BrowsersTest {
 
-    private void testSite(FirefoxDriver driver, String site) throws InterruptedException {
+    private void testSite(WebDriver driver, String site) throws InterruptedException {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud("http://" + site);
         GenericUnitTest.runAllTests(driver);
@@ -38,53 +38,53 @@ public class TopSitesUnitTest extends BrowsersTest {
         GenericUnitTest.runAllTests(driver);
     }
 
-    @Test
-    public void testGoogle(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testGoogle(WebDriver driver) throws InterruptedException {
         testSite(driver, "google.com");
     }
 
-    @Test
-    public void testYoutube(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testYoutube(WebDriver driver) throws InterruptedException {
         testSite(driver, "youtube.com");
     }
 
-    @Test
-    public void testFacebook(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testFacebook(WebDriver driver) throws InterruptedException {
         testSite(driver, "facebook.com");
     }
 
-    @Test
-    public void testBaidu(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testBaidu(WebDriver driver) throws InterruptedException {
         testSite(driver, "www.baidu.com");
     }
 
-    @Test
-    public void testWikipedia(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testWikipedia(WebDriver driver) throws InterruptedException {
         testSite(driver, "www.wikipedia.org");
     }
 
-    @Test
-    public void testQq(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testQq(WebDriver driver) throws InterruptedException {
         testSite(driver, "www.qq.com");
     }
 
-    @Test
-    public void testYahoo(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testYahoo(WebDriver driver) throws InterruptedException {
         testSite(driver, "yahoo.com");
     }
 
-    @Test
-    public void testTaobao(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testTaobao(WebDriver driver) throws InterruptedException {
         testSite(driver, "taobao.com");
     }
 
-    @Test
-    public void testTmall(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testTmall(WebDriver driver) throws InterruptedException {
         testSite(driver, "tmall.com");
     }
 
-    @Test
-    public void testAmazon(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testAmazon(WebDriver driver) throws InterruptedException {
         testSite(driver, "amazon.com");
     }
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/TrickySitesUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/TrickySitesUnitTest.java
@@ -20,8 +20,8 @@
 package org.zaproxy.zap.extension.hud.ui.browser;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.openqa.selenium.firefox.FirefoxDriver;
+import org.junit.jupiter.api.TestTemplate;
+import org.openqa.selenium.WebDriver;
 import org.zaproxy.zap.extension.hud.ui.generic.GenericUnitTest;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
@@ -29,7 +29,7 @@ import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 /** Sites that have been known to cause the HUD problems. Expect this to be added to! */
 public class TrickySitesUnitTest extends BrowsersTest {
 
-    private void testSite(FirefoxDriver driver, String site) throws InterruptedException {
+    private void testSite(WebDriver driver, String site) throws InterruptedException {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud("http://" + site);
         GenericUnitTest.runAllTests(driver);
@@ -38,8 +38,8 @@ public class TrickySitesUnitTest extends BrowsersTest {
         GenericUnitTest.runAllTests(driver);
     }
 
-    @Test
-    public void testBbc(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testBbc(WebDriver driver) throws InterruptedException {
         testSite(driver, "bbc.com");
     }
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/badsite/BadSiteUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/badsite/BadSiteUnitTest.java
@@ -34,12 +34,11 @@ import javax.net.ssl.X509TrustManager;
 import net.sf.json.JSONObject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.zaproxy.zap.extension.hud.HudAPI;
 import org.zaproxy.zap.extension.hud.tutorial.pages.IntroPage;
@@ -82,8 +81,8 @@ public class BadSiteUnitTest extends BrowsersTest {
         }
     }
 
-    @Test
-    public void cannotAccessWebSocketsUrlWhenLoadingSwAsScript(FirefoxDriver driver)
+    @TestTemplate
+    public void cannotAccessWebSocketsUrlWhenLoadingSwAsScript(WebDriver driver)
             throws InterruptedException, MalformedURLException {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
@@ -98,7 +97,7 @@ public class BadSiteUnitTest extends BrowsersTest {
         sb.append("document.head.appendChild(script);\n");
 
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
-        driver.executeScript(sb.toString());
+        ((JavascriptExecutor) driver).executeScript(sb.toString());
 
         // Now try to make use of it
 
@@ -106,17 +105,17 @@ public class BadSiteUnitTest extends BrowsersTest {
         assertTrue(result.toString().startsWith("https://zap//zapCallBackUrl"));
         try {
             // ZAP_HUD_WS should be protected via a closure
-            result = driver.executeScript("return ZAP_HUD_WS;");
+            result = ((JavascriptExecutor) driver).executeScript("return ZAP_HUD_WS;");
             // This class should not expect a JavascriptException in case the script above fails
             fail();
         } catch (JavascriptException e) {
             // Expected, but double check the error message
-            assertTrue(e.getMessage().contains("ReferenceError: ZAP_HUD_WS is not defined"));
+            assertTrue(e.getMessage().contains("ZAP_HUD_WS is not defined"));
         }
     }
 
-    @Test
-    public void cannotUseZapApiFromTarget(FirefoxDriver driver)
+    @TestTemplate
+    public void cannotUseZapApiFromTarget(WebDriver driver)
             throws InterruptedException, IOException {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/AlertNotificationsPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/AlertNotificationsPageUnitTest.java
@@ -25,11 +25,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 import org.zaproxy.zap.extension.hud.tutorial.pages.AlertNotificationsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.AlertsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.PageAlertsPage;
@@ -40,15 +40,15 @@ import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 @Tag("tutorial")
 public class AlertNotificationsPageUnitTest extends BrowsersTest {
 
-    @Test
-    public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void genericPageUnitTests(WebDriver driver) throws InterruptedException {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertNotificationsPage.NAME));
         GenericUnitTest.runAllTests(driver);
     }
 
-    @Test
-    public void testPreviousButtonWorks(FirefoxDriver driver) {
+    @TestTemplate
+    public void testPreviousButtonWorks(WebDriver driver) {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertNotificationsPage.NAME));
         WebElement previousButton = TutorialStatics.getPreviousButton(driver);
@@ -57,9 +57,10 @@ public class AlertNotificationsPageUnitTest extends BrowsersTest {
         assertEquals(TutorialStatics.getTutorialHudUrl(AlertsPage.NAME), driver.getCurrentUrl());
     }
 
-    @Test
+    @TestTemplate
     @Disabled
-    public void testTaskAndNextButton(FirefoxDriver driver) {
+    public void testTaskAndNextButton(WebDriver driver) throws Exception {
+        HUD.callZapApiResetTasks();
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertNotificationsPage.NAME));
 

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/AlertsPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/AlertsPageUnitTest.java
@@ -23,9 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 import org.zaproxy.zap.extension.hud.tutorial.pages.AlertNotificationsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.AlertsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.FramesPage;
@@ -36,15 +36,15 @@ import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 @Tag("tutorial")
 public class AlertsPageUnitTest extends BrowsersTest {
 
-    @Test
-    public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void genericPageUnitTests(WebDriver driver) throws InterruptedException {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertsPage.NAME));
         GenericUnitTest.runAllTests(driver);
     }
 
-    @Test
-    public void testPreviousButtonWorks(FirefoxDriver driver) {
+    @TestTemplate
+    public void testPreviousButtonWorks(WebDriver driver) {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertsPage.NAME));
         WebElement previousButton = TutorialStatics.getPreviousButton(driver);
@@ -53,8 +53,8 @@ public class AlertsPageUnitTest extends BrowsersTest {
         assertEquals(TutorialStatics.getTutorialHudUrl(FramesPage.NAME), driver.getCurrentUrl());
     }
 
-    @Test
-    public void testNextPageButtonWorks(FirefoxDriver driver) {
+    @TestTemplate
+    public void testNextPageButtonWorks(WebDriver driver) {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertsPage.NAME));
         WebElement nextButton = TutorialStatics.getNextButton(driver);

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/FramesPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/FramesPageUnitTest.java
@@ -28,12 +28,11 @@ import java.util.List;
 import java.util.function.Function;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.zaproxy.zap.extension.hud.tutorial.pages.AlertsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.FramesPage;
@@ -46,15 +45,15 @@ import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 @Tag("tutorial")
 public class FramesPageUnitTest extends BrowsersTest {
 
-    @Test
-    public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void genericPageUnitTests(WebDriver driver) throws InterruptedException {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(FramesPage.NAME));
         GenericUnitTest.runAllTests(driver);
     }
 
-    @Test
-    public void testPreviousButtonWorks(FirefoxDriver driver) {
+    @TestTemplate
+    public void testPreviousButtonWorks(WebDriver driver) {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(FramesPage.NAME));
         WebElement previousButton = TutorialStatics.getPreviousButton(driver);
@@ -63,8 +62,8 @@ public class FramesPageUnitTest extends BrowsersTest {
         assertEquals(TutorialStatics.getTutorialHudUrl(UpgradePage.NAME), driver.getCurrentUrl());
     }
 
-    @Test
-    public void testTaskAndNextButton(FirefoxDriver driver) throws Exception {
+    @TestTemplate
+    public void testTaskAndNextButton(WebDriver driver) throws Exception {
         HUD.callZapApiResetTasks();
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(FramesPage.NAME));
@@ -98,8 +97,8 @@ public class FramesPageUnitTest extends BrowsersTest {
         assertEquals(TutorialStatics.getTutorialHudUrl(AlertsPage.NAME), driver.getCurrentUrl());
     }
 
-    @Test
-    public void testSidePanelsHiddenAndRevealed(FirefoxDriver driver) throws Exception {
+    @TestTemplate
+    public void testSidePanelsHiddenAndRevealed(WebDriver driver) throws Exception {
         HUD.callZapApiResetTasks();
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(FramesPage.NAME));
@@ -121,9 +120,8 @@ public class FramesPageUnitTest extends BrowsersTest {
         testSidePanesVisible(hud);
     }
 
-    @Test
-    public void testBottonDrawerTabsHiddenAndRevealed(FirefoxDriver driver)
-            throws URISyntaxException {
+    @TestTemplate
+    public void testBottonDrawerTabsHiddenAndRevealed(WebDriver driver) throws URISyntaxException {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(FramesPage.NAME));
 

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/PageAlertsPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/PageAlertsPageUnitTest.java
@@ -25,11 +25,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 import org.zaproxy.zap.extension.hud.tutorial.pages.AlertNotificationsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.PageAlertsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.SiteAlertsPage;
@@ -41,15 +41,15 @@ import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 @Tag("tutorial")
 public class PageAlertsPageUnitTest extends BrowsersTest {
 
-    @Test
-    public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void genericPageUnitTests(WebDriver driver) throws InterruptedException {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(PageAlertsPage.NAME));
         GenericUnitTest.runAllTests(driver);
     }
 
-    @Test
-    public void testPreviousButtonWorks(FirefoxDriver driver) {
+    @TestTemplate
+    public void testPreviousButtonWorks(WebDriver driver) {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(PageAlertsPage.NAME));
         WebElement previousButton = TutorialStatics.getPreviousButton(driver);
@@ -60,8 +60,9 @@ public class PageAlertsPageUnitTest extends BrowsersTest {
                 driver.getCurrentUrl());
     }
 
-    @Test
-    public void testTaskAndNextButton(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void testTaskAndNextButton(WebDriver driver) throws Exception {
+        HUD.callZapApiResetTasks();
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(PageAlertsPage.NAME));
 

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/WarningPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/WarningPageUnitTest.java
@@ -23,9 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 import org.zaproxy.zap.extension.hud.tutorial.pages.IntroPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.UpgradePage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.WarningPage;
@@ -36,15 +36,15 @@ import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 @Tag("tutorial")
 public class WarningPageUnitTest extends BrowsersTest {
 
-    @Test
-    public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void genericPageUnitTests(WebDriver driver) throws InterruptedException {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(WarningPage.NAME));
         GenericUnitTest.runAllTests(driver);
     }
 
-    @Test
-    public void testPreviousButtonWorks(FirefoxDriver driver) {
+    @TestTemplate
+    public void testPreviousButtonWorks(WebDriver driver) {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(WarningPage.NAME));
         WebElement previousButton = TutorialStatics.getPreviousButton(driver);
@@ -53,8 +53,8 @@ public class WarningPageUnitTest extends BrowsersTest {
         assertEquals(TutorialStatics.getTutorialHudUrl(IntroPage.NAME), driver.getCurrentUrl());
     }
 
-    @Test
-    public void testNextPageButtonWorks(FirefoxDriver driver) {
+    @TestTemplate
+    public void testNextPageButtonWorks(WebDriver driver) {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(WarningPage.NAME));
         WebElement nextButton = TutorialStatics.getNextButton(driver);

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/WelcomePageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/WelcomePageUnitTest.java
@@ -24,10 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 import org.zaproxy.zap.extension.hud.tutorial.pages.IntroPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.WarningPage;
 import org.zaproxy.zap.extension.hud.ui.browser.BrowsersTest;
@@ -37,22 +37,22 @@ import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 @Tag("tutorial")
 public class WelcomePageUnitTest extends BrowsersTest {
 
-    @Test
-    public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {
+    @TestTemplate
+    public void genericPageUnitTests(WebDriver driver) throws InterruptedException {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
         GenericUnitTest.runAllTests(driver);
     }
 
-    @Test
-    public void testRedirectToHttps(FirefoxDriver driver) {
+    @TestTemplate
+    public void testRedirectToHttps(WebDriver driver) {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
         assertEquals(TutorialStatics.getTutorialHudUrl(IntroPage.NAME), driver.getCurrentUrl());
     }
 
-    @Test
-    public void testNoPreviousButton(FirefoxDriver driver) {
+    @TestTemplate
+    public void testNoPreviousButton(WebDriver driver) {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
         assertThrows(
@@ -62,8 +62,8 @@ public class WelcomePageUnitTest extends BrowsersTest {
                 });
     }
 
-    @Test
-    public void testNextPageButtonWorks(FirefoxDriver driver) {
+    @TestTemplate
+    public void testNextPageButtonWorks(WebDriver driver) {
         HUD hud = new HUD(driver);
         hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
         WebElement nextButton = TutorialStatics.getNextButton(driver);


### PR DESCRIPTION
Change `BrowsersTest` to include Chrome (commented until the tests are
more reliable #344), also, use `proxy` instead of manually setting the
proxy preferences to Firefox.
Update all browser tests to run the tests with multiple browsers (by
using `TestTemplate`).
Change `testTaskAndNextButton` in `AlertNotificationsPageUnitTest` and
`PageAlertsPageUnitTest` to reset the tasks' state to have the task in
the expected state for each browser.
Tweak exception message asserted in `BadSiteUnitTest` to work with
multiple browsers (the message prefix is different).
Update Selenium-Jupiter, required for testing with multiple browsers.
Remove test home always, to run the tests with fresh ZAP.

Part of #345 - Run functional tests with Chrome

---
Old description:

Initial changes for #345.

The (tutorial) test classes are still in the `firefox` package and the base class is still named after Firefox. (That will be changed once we decide how we want the tests to be executed by the browsers.)
Currently each test method is being executed sequentially by the browsers (Firefox then Chrome) which causes some tests to fail as the preconditions are no longer met (i.e. tutorial task is already completed). Should all tests be executed by one browser, ZAP reset and then the other browser? Or, change the test methods to ensure the preconditions are the expected for each browser?