### PR TITLE
Persist the UI configs to ZAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Add css transitions to tool buttons so that they slide out when hovered over.
  - Initial support for WebSockets - this adds a new lower tab that shows all of the WebSocket messages proxied through ZAP 
 
+### Fixed
+ - The UI configs are now persisted to ZAP [#321](https://github.com/zaproxy/zap-hud/issues/321)
+
 ## [0.3.0] - 2019-02-11
  - Many thanks to Matt Austin (@mattaustin) for reporting security vulnerabilities with the HUD and working with us to fix them.
 

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -448,7 +448,18 @@ public class HudAPI extends ApiImplementor {
                         }
                     }
                     // The single quotes are to keep the JS linter happy
-                    contents = contents.replace("'<<ZAP_HUD_TOOLS>>'", sb.toString());
+                    contents =
+                            contents.replace("'<<ZAP_HUD_TOOLS>>'", sb.toString())
+                                    .replace(
+                                            "'<<ZAP_HUD_CONFIG_TOOLS_LEFT>>'",
+                                            extension
+                                                    .getHudParam()
+                                                    .getUiOption(HudParam.UI_OPTION_LEFT_PANEL))
+                                    .replace(
+                                            "'<<ZAP_HUD_CONFIG_TOOLS_RIGHT>>'",
+                                            extension
+                                                    .getHudParam()
+                                                    .getUiOption(HudParam.UI_OPTION_RIGHT_PANEL));
                 } else if (file.equals("i18n.js")) {
                     contents =
                             contents.replace(

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudParam.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudParam.java
@@ -29,6 +29,14 @@ import org.zaproxy.zap.extension.api.ZapApiIgnore;
 
 public class HudParam extends VersionedAbstractParam {
 
+    public static final String UI_OPTION_LEFT_PANEL = "leftPanel";
+    public static final String UI_OPTION_RIGHT_PANEL = "rightPanel";
+
+    private static final String ZAP_HUD_CONFIG_TOOLS_LEFT =
+            "['scope', 'break', 'showEnable', 'page-alerts-high', 'page-alerts-medium', 'page-alerts-low', 'page-alerts-informational']";
+    private static final String ZAP_HUD_CONFIG_TOOLS_RIGHT =
+            "['site-tree', 'spider', 'active-scan', 'attack', 'site-alerts-high', 'site-alerts-medium', 'site-alerts-low', 'site-alerts-informational']";
+
     /** The base configuration key for all HUD configurations. */
     private static final String PARAM_BASE_KEY = "hud";
 
@@ -295,6 +303,18 @@ public class HudParam extends VersionedAbstractParam {
     }
 
     public String getUiOption(String key) {
-        return getConfig().getString(PARAM_UI_OPTION_PREFIX + key, "");
+        String value = getConfig().getString(PARAM_UI_OPTION_PREFIX + key, "");
+        if (value.length() == 0) {
+            // Set the relevant default values
+            switch (key) {
+                case UI_OPTION_LEFT_PANEL:
+                    value = ZAP_HUD_CONFIG_TOOLS_LEFT;
+                    break;
+                case UI_OPTION_RIGHT_PANEL:
+                    value = ZAP_HUD_CONFIG_TOOLS_RIGHT;
+                    break;
+            }
+        }
+        return value;
     }
 }

--- a/src/main/zapHomeFiles/hud/serviceworker.js
+++ b/src/main/zapHomeFiles/hud/serviceworker.js
@@ -3,6 +3,9 @@ var ZAP_HUD_FILES = '<<ZAP_HUD_FILES>>';
 var toolScripts = [
 	'<<ZAP_HUD_TOOLS>>'
 ];
+// The configured tools
+var CONFIG_TOOLS_LEFT = '<<ZAP_HUD_CONFIG_TOOLS_LEFT>>';
+var CONFIG_TOOLS_RIGHT = '<<ZAP_HUD_CONFIG_TOOLS_RIGHT>>';
 
 importScripts(ZAP_HUD_FILES + "?name=libraries/localforage.min.js"); 
 importScripts(ZAP_HUD_FILES + "?name=libraries/vue.js"); 
@@ -56,9 +59,61 @@ localforage.setItem("tools", [])
 	})
 	.catch(utils.errorHandler);
 
-const onInstall = event => {
-	utils.log(LOG_INFO, 'serviceworker.install', 'Installing...');
+initWebSockets();
 
+function initWebSockets() {
+	/* Set up WebSockets */
+	let ZAP_HUD_WS = '<<ZAP_HUD_WS>>';
+	webSocket = new WebSocket(ZAP_HUD_WS);
+
+	webSocket.onopen = function (event) {
+		// Wont be able to log until ther websocket is set up
+		utils.log(LOG_INFO, 'serviceworker.initWebSockets', 'Initialized');
+		// Basic test
+		webSocket.send('{ "component" : "core", "type" : "view", "name" : "version" }'); 
+
+		apiCallWithResponse("hud", "view", "upgradedDomains")
+		.then(response => {
+			let upgradedDomains = {};
+
+			for (const domain of response.upgradedDomains) {
+				upgradedDomains[domain] = true;
+			}
+			return localforage.setItem('upgradedDomains', upgradedDomains);
+		})
+		.catch(utils.errorHandler);
+	};
+
+	webSocket.onmessage = function (event) {
+		// Rebroadcast for the tools to pick up
+		let jevent = JSON.parse(event.data);
+
+		if ('event.publisher' in jevent) {
+			utils.log(LOG_DEBUG, 'serviceworker.webSocket.onmessage', jevent['event.publisher']);
+			var ev = new CustomEvent(jevent['event.publisher'], {detail: jevent});
+			self.dispatchEvent(ev);
+		} else if ('id' in jevent && 'response' in jevent) {
+			let pFunctions = webSocketCallbacks[jevent['id']];
+			let response = jevent['response'];
+			if ('code' in response && 'message' in response) {
+				// These always indicate a failure
+				let error = new Error(I18n.t("error_with_message", [response['message']]));
+				error.response = response;
+
+				pFunctions.reject(error);
+			} else {
+				pFunctions.resolve(response);
+			}
+			delete webSocketCallbacks[jevent['id']];
+		}
+	};
+
+	webSocket.onerror = function (event) {
+		utils.log(LOG_ERROR, 'websocket', '', event);
+	};
+};
+
+const onInstall = event => {
 	// Cache Files
 	// not sure caching in service worker provides advantage over browser - may be able to remove
 	event.waitUntil(
@@ -69,18 +124,18 @@ const onInstall = event => {
 			.catch(utils.errorHandler)
 	);
 };
-
+	
 const onActivate = event => {
 	// Check Storage & Initiate
 	event.waitUntil(
 		utils.isHUDInitialized()
 			.then(isInitialized => {
 				if (!isInitialized) {
-					return utils.initializeHUD();
+					return utils.initializeHUD(CONFIG_TOOLS_LEFT, CONFIG_TOOLS_RIGHT);
 				}
 			})
 			.catch(utils.errorHandler)
-	);
+		);
 };
 
 // if we remove cache we can remove this as well
@@ -155,72 +210,32 @@ const logHandler = event => {
 	apiCall("hud", "action", "log", { record: event.detail.record });
 };
 
+const backupHandler = event => {
+	backup(event.detail.key, event.detail.value);
+};
+
+function backup(key, value) {
+	apiCall("hud", "action", "setUiOption", { key: key, value: value });
+}
+
 self.addEventListener("install", onInstall); 
 self.addEventListener("activate", onActivate);
 self.addEventListener("fetch", onFetch);
 self.addEventListener("message", onMessage);
 self.addEventListener('error', utils.errorHandler);
 self.addEventListener('hud.log', logHandler);
-
-/* Set up WebSockets */
-
-{
-	let ZAP_HUD_WS = '<<ZAP_HUD_WS>>';
-	webSocket = new WebSocket(ZAP_HUD_WS);
-}
-
-webSocket.onopen = function (event) {
-	// Basic test
-	webSocket.send('{ "component" : "core", "type" : "view", "name" : "version" }'); 
-	// Tools should register for alerts via the registerForWebSockerEvents function - see the break tool
-
-	apiCallWithResponse("hud", "view", "upgradedDomains")
-		.then(response => {
-			let upgradedDomains = {};
-
-			for (const domain of response.upgradedDomains) {
-				upgradedDomains[domain] = true;
-			}
-			return localforage.setItem('upgradedDomains', upgradedDomains);
-		})
-		.catch(utils.errorHandler);
-};
-
-webSocket.onmessage = function (event) {
-	// Rebroadcast for the tools to pick up
-	let jevent = JSON.parse(event.data);
-
-	if ('event.publisher' in jevent) {
-		utils.log(LOG_DEBUG, 'serviceworker.webSocket.onmessage', jevent['event.publisher']);
-		var ev = new CustomEvent(jevent['event.publisher'], {detail: jevent});
-		self.dispatchEvent(ev);
-	} else if ('id' in jevent && 'response' in jevent) {
-		let pFunctions = webSocketCallbacks[jevent['id']];
-		let response = jevent['response'];
-		if ('code' in response && 'message' in response) {
-			// These always indicate a failure
-			let error = new Error(I18n.t("error_with_message", [response['message']]));
-			error.response = response;
-
-			pFunctions.reject(error);
-		} else {
-			pFunctions.resolve(response);
-		}
-		delete webSocketCallbacks[jevent['id']];
-	} else {
-		utils.log(LOG_DEBUG, 'serviceworker.webSocket.onmessage', 'Unexpected message', jevent);
-	}
-};
-
-webSocket.onerror = function (event) {
-	utils.log(LOG_ERROR, 'websocket', '', event);
-};
+self.addEventListener('hud.backup', backupHandler);
 
 function registerForZapEvents(publisher) {
 	apiCall("event", "register", publisher);
 };
 
 function apiCall(component, type, name, params) {
+	if (!webSocket) {
+		// Can't use utils.log here as that could then put us in a loop
+		console.log("serviceworker.apiCall no WebSocket " + component + " " + type + " " + name);
+		return;
+	}
 	if (! params) {
 		params = {};
 	}
@@ -229,6 +244,10 @@ function apiCall(component, type, name, params) {
 };
 
 function apiCallWithResponse(component, type, name, params) {
+	if (!webSocket) {
+		console.log("serviceworker.apiCallWithResponse no WebSocket " + component + " " + type + " " + name);
+		return;
+	}
 	if (! params) {
 		params = {};
 	}
@@ -288,16 +307,27 @@ function showHudSettings(tabId) {
 };
 
 function resetToDefault() {
-	utils.initializeHUD()
-		.then(utils.loadAllTools)
+	utils.loadAllTools()
 		.then(tools => {
 			var promises = [];
+			// Clearing these values means they will go back to the default when next read
+			promises.push(backup('leftPanel', ''));
+			promises.push(backup('rightPanel', ''));
 
 			for (var tool in tools) {
-				promises.push(self.tools[tools[tool].name].initialize());
+				self.tools[tools[tool].name].initialize();
 			}
 
 			return Promise.all(promises);
+		})
+		.then(() => {
+			var promises = [];
+			promises.push(apiCallWithResponse("hud", "view", "getUiOption",  { key: 'leftPanel' }));
+			promises.push(apiCallWithResponse("hud", "view", "getUiOption",  { key: 'rightPanel' }));
+			return Promise.all(promises);
+		})
+		.then(responses => {
+			return utils.initializeHUD(responses[0].leftPanel, responses[1].rightPanel);
 		})
 		.then(utils.messageAllTabs("management", {action: "refreshTarget"}))
 		.catch(utils.errorHandler);

--- a/src/main/zapHomeFiles/hud/tools/activeScan.js
+++ b/src/main/zapHomeFiles/hud/tools/activeScan.js
@@ -37,7 +37,6 @@ var ActiveScan = (function() {
 		tool.scanid = -1;
 
 		utils.writeTool(tool);
-		registerForZapEvents(ACTIVE_SCAN_EVENT);
 	}
 
 	function showDialog(tabId, domain) {
@@ -215,6 +214,7 @@ var ActiveScan = (function() {
 
 	self.addEventListener("activate", event => {
 		initializeStorage();
+		registerForZapEvents(ACTIVE_SCAN_EVENT);
 	});
 
 	self.addEventListener("message", event => {

--- a/src/main/zapHomeFiles/hud/tools/break.js
+++ b/src/main/zapHomeFiles/hud/tools/break.js
@@ -33,7 +33,6 @@ var Break = (function() {
 		tool.position = 0;
 
 		utils.writeTool(tool);
-		registerForZapEvents("org.zaproxy.zap.extension.brk.BreakEventPublisher");
 	}
 
 	function toggleBreak(tabId) {
@@ -222,6 +221,7 @@ var Break = (function() {
 
 	self.addEventListener("activate", event => {
 		initializeStorage();
+		registerForZapEvents("org.zaproxy.zap.extension.brk.BreakEventPublisher");
 	});
 
 	self.addEventListener("message", event => {

--- a/src/main/zapHomeFiles/hud/tools/commonAlerts.js
+++ b/src/main/zapHomeFiles/hud/tools/commonAlerts.js
@@ -28,8 +28,6 @@ var CommonAlerts = (function() {
 		tool.alerts = {};
 
 		utils.writeTool(tool);
-		registerForZapEvents("org.zaproxy.zap.extension.alert.AlertEventPublisher");
-		registerForZapEvents("org.zaproxy.zap.extension.hud.HudEventPublisher");
 	}
 
 	function showGrowlerAlert(alert) {
@@ -38,6 +36,8 @@ var CommonAlerts = (function() {
 
 	self.addEventListener("activate", event => {
 		initializeStorage();
+		registerForZapEvents("org.zaproxy.zap.extension.alert.AlertEventPublisher");
+		registerForZapEvents("org.zaproxy.zap.extension.hud.HudEventPublisher");
 	});
 
 	self.addEventListener("message", event => {

--- a/src/main/zapHomeFiles/hud/tools/history.js
+++ b/src/main/zapHomeFiles/hud/tools/history.js
@@ -27,7 +27,6 @@ var History = (function() {
         tool.messages = [];
 
         utils.writeTool(tool);
-        registerForZapEvents("org.parosproxy.paros.extension.history.ProxyListenerLogEventPublisher");
 	}
 
 	function showOptions(tabId) {
@@ -140,6 +139,7 @@ var History = (function() {
 
 	self.addEventListener("activate", event => {
 		initializeStorage();
+		registerForZapEvents("org.parosproxy.paros.extension.history.ProxyListenerLogEventPublisher");
 	});
 
 	function trimMessages(lastPageUnloadTime) {

--- a/src/main/zapHomeFiles/hud/tools/spider.js
+++ b/src/main/zapHomeFiles/hud/tools/spider.js
@@ -34,7 +34,6 @@ var Spider = (function() {
 		tool.runningTabId = '';
 
 		utils.writeTool(tool);
-		registerForZapEvents("org.zaproxy.zap.extension.spider.SpiderEventPublisher");
 	}
 
 	function showDialog(tabId, domain) {
@@ -194,6 +193,7 @@ var Spider = (function() {
 
 	self.addEventListener("activate", event => {
 		initializeStorage();
+		registerForZapEvents("org.zaproxy.zap.extension.spider.SpiderEventPublisher");
 	});
 
 	self.addEventListener("message", event => {

--- a/src/main/zapHomeFiles/hud/tools/websockets.js
+++ b/src/main/zapHomeFiles/hud/tools/websockets.js
@@ -26,7 +26,6 @@ var WebSockets = (function() {
 		tool.messages = [];
 
 		utils.writeTool(tool);
-		registerForZapEvents("org.zaproxy.zap.extension.websocket.WebSocketEventPublisher");
 	}
 
 	function showOptions(tabId) {
@@ -73,6 +72,7 @@ var WebSockets = (function() {
 
 	self.addEventListener("activate", event => {
 		initializeStorage();
+		registerForZapEvents("org.zaproxy.zap.extension.websocket.WebSocketEventPublisher");
 	});
 
 	function trimMessages(lastPageUnloadTime) {


### PR DESCRIPTION
Fixes #321 

The tools are now read from the ZAP configs via the API - if they are not set then they are defaulted to the values now held in serviceworker.js
I suspect this is slowing down start up a little bit but I dont have any measurements to prove it.
Injecting the default values into serviceworker.js would probably involve fewer changes and be quicker, but I thought I'd try the 'right' way first :)
I've seen a couple of cases where the tools are duplicated - this looks like its a client side issue as the values stored in the ZAP config file have been correct. I'm guessing its a timing issue when loading the tools but will need to check that.
General feedback appreciated - I'll look into the above bug asap.
It might also be worth waiting until #351 is merged before merging this one.