### PR TITLE
add transitions to buttons

### DIFF
--- a/src/main/zapHomeFiles/hud/libraries/spectre.css
+++ b/src/main/zapHomeFiles/hud/libraries/spectre.css
@@ -2306,11 +2306,22 @@ html {
     clear: both;
     cursor: pointer;
   }
+
+  .hud-button #label {
+    max-width: 0px;
+    white-space: nowrap;
+    overflow: hidden;
+    transition-property: all;
+    transition-duration: .5s;
+  }
   
   .hud-button.active {
     background: #e4e4f8;
-    display: inline-block;
     color: #667189;
+  }
+
+  .hud-button.active #label {
+    max-width: 100px;
   }
 
   .hud-button.disabled {

--- a/src/main/zapHomeFiles/hud/panel.html
+++ b/src/main/zapHomeFiles/hud/panel.html
@@ -21,10 +21,10 @@
 	</template>
 
 	<template id="hud-button-template">
-		<div :class="{'hud-button': true, 'small': isSmall, 'active': isActive, 'disabled': isDisabled}" :style="{'float': orientation}" @click="selectButton" @contextmenu="showContextMenu" @mouseover="mouseOver" @mouseleave="mouseLeave">
+		<div :class="{'hud-button': true, 'small': isSmall, 'active': isActive, 'disabled': isDisabled}" :style="{'float': orientation, 'direction': direction}" @click="selectButton" @contextmenu="showContextMenu" @mouseover="mouseOver" @mouseleave="mouseLeave">
 			<img :src="currentIcon" :style="{'float': orientation}">
-			<div v-show="showData" :style="{'float': orientation, 'margin-left': marginleft, 'margin-right': marginright}">{{currentData}}</div>
-			<div v-show="showLabel" :style="{'float': orientation, 'margin-left': marginleft, 'margin-right': marginright}">{{label}}</div>
+			<span id="data" v-show="showData" :style="{'float': orientation, 'margin-left': marginleft, 'margin-right': marginright}">{{currentData}}</span>
+			<span id="label" @transitionend="transitionEnd" :style="{'float': orientation, 'margin-left': labelmarginleft, 'margin-right': labelmarginright}">{{label}}</span>
 		</div>
 	</template>
 </body>

--- a/src/main/zapHomeFiles/hud/panel.js
+++ b/src/main/zapHomeFiles/hud/panel.js
@@ -28,12 +28,15 @@ Vue.component('hud-button', {
 			currentData: this.data,
 			currentIcon: this.icon,
 			showData: true,
-			showLabel: false,
 			orientation: orientation,
 			marginleft: '0rem',
 			marginright: '0rem',
+			labelmarginleft: '0rem',
+			labelmarginright: '0rem',
 			isActive: false,
-			isDisabled: false
+			isDisabled: false,
+			isClosed: true,
+			direction: 'ltr'
 		}
 	},
 	computed: {
@@ -58,14 +61,33 @@ Vue.component('hud-button', {
 			navigator.serviceWorker.controller.postMessage({action: "buttonMenuClicked", tool: this.name, frameId: frameId, tabId: tabId});
 		},
 		mouseOver() {
-			this.showLabel = true;
+			this.labelmarginleft = this.marginleft;
+			this.labelmarginright = this.marginright;
 			this.isActive = true;
+			this.isClosed = false;
 			expandPanel();
 		},
 		mouseLeave() {
-			this.showLabel = false;
+			this.labelmarginleft = '0rem';
+			this.labelmarginright = '0rem';
 			this.isActive = false;
-			contractPanel();
+		},
+		transitionEnd() {
+			let areAllButtonsClosed = true;
+
+			if (!this.isActive) {
+				this.isClosed = true;
+			}
+
+			this.$parent.$children.forEach(child => {
+				if (!child.isClosed) {
+					areAllButtonsClosed = false;
+				}
+			})
+
+			if (areAllButtonsClosed) {
+				contractPanel();
+			}
 		}
 	},
 	created() {
@@ -74,9 +96,11 @@ Vue.component('hud-button', {
 		// set the margins depending on the orientation
 		if (orientation === 'left') {
 			self.marginleft = '.5rem';
+			self.direction = "ltr"
 		}
 		else {
 			self.marginright = '.5rem'
+			self.direction = "rtl"
 		}
 
 		eventBus.$on('updateButton', data => {


### PR DESCRIPTION
This adds transitions to the buttons when you hover over them to make them slide open. 

The panels will wait until all buttons have closed before shrinking the iframe back down. (add a border to the iframe if you're curious about this)

![slidey-buttons](https://user-images.githubusercontent.com/5150944/52906752-b8e9ca00-3207-11e9-84b2-8ce7dc5ffd75.gif)
