### PR TITLE
Add basic telemetry WIP

### DIFF
--- a/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -67,11 +67,11 @@ public class HudAPI extends ApiImplementor {
 
     // TODO shouldnt allow unsafe-inline styles - need to work out where they are being used
     protected static final String CSP_POLICY =
-            "default-src 'none'; script-src 'self'; connect-src https://zap wss://zap; frame-src 'self'; img-src 'self' data:; "
+            "default-src 'none'; script-src 'self'; connect-src https://zap wss://zap; frame-src 'self'; img-src 'self' data: https://bit.ly; "
                     + "font-src 'self' data:; style-src 'self' 'unsafe-inline' ;";
 
     protected static final String CSP_POLICY_UNSAFE_EVAL =
-            "default-src 'none'; script-src 'self' 'unsafe-eval'; connect-src https://zap wss://zap; frame-src 'self'; img-src 'self' data:; "
+            "default-src 'none'; script-src 'self' 'unsafe-eval'; connect-src https://zap wss://zap; frame-src 'self'; img-src 'self' data: https://bit.ly; "
                     + "font-src 'self' data:; style-src 'self' 'unsafe-inline' ;";
 
     private static final String PREFIX = "hud";

--- a/src/main/zapHomeFiles/hud/management.js
+++ b/src/main/zapHomeFiles/hud/management.js
@@ -72,6 +72,11 @@ document.addEventListener('DOMContentLoaded', () => {
 		localforage.setItem('is_first_load', true)
 
 		startServiceWorker();
+		
+		var img = new Image(1, 1);
+		img.src = 'https://bit.ly/owaspzap-hud-0-4';
+		img.style = 'display: none;';
+		document.body.appendChild(img);
 	}
 	else {
 		parent.postMessage( {action: 'showAllDisplayFrames'} , document.referrer);

--- a/src/main/zapHomeFiles/hudtutorial/en_GB/Complete.html
+++ b/src/main/zapHomeFiles/hudtutorial/en_GB/Complete.html
@@ -5,6 +5,7 @@
 	<link href="tutorial.css" rel="stylesheet" type="text/css" />
 </head>
 <body>
+<img src="https://bit.ly/owaspzap-hud-tutorial-end" style="display: none;" />
 <div class="roundContainer">
 	<h1>Tutorial Completed</H1>
 	Congratulations, you have completed this HUD tutorial!

--- a/src/main/zapHomeFiles/hudtutorial/en_GB/Intro.html
+++ b/src/main/zapHomeFiles/hudtutorial/en_GB/Intro.html
@@ -6,6 +6,7 @@
 	<script src="Tutorial.js"></script> 
 </head>
 <body>
+<img src="https://bit.ly/owaspzap-hud-tutorial-start" style="display: none;" />
 <div class="roundContainer">
 	<h1>Welcome to the HUD</H1>
 	The HUD is a completely new way to interact with ZAP.<br>


### PR DESCRIPTION
This adds 3 hidden images that try (and fail;) to load bitly links (which 404):

- When the HUD initializes: https://bit.ly/owaspzap-hud-0-4+
- First page of the tutorial: https://bit.ly/owaspzap-hud-tutorial-start+
- Last page of the tutorial: https://bit.ly/owaspzap-hud-tutorial-end+

The above links are for the relevant stats, the actual URLs dont have the trailing plus.

Note that the initialize link has a hardcoded version in it - I think this is really useful but we'll need to work out if we're ok manually changing it each time or if we can automate it more effectively.

I realise there's a huge amount of telemetry we're _really_ like but this seemed to be to be a minimal useful initial set :)

Feedback from all appreciated!