### PR TITLE
Chore/add docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ZAP_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 # JS
 node_modules/
 dist/
+
+# Docker/Docker Compose
+.env

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Learn more:
 
 ## Using the HUD
 
-### Downloading
+### Usage
+
+#### From Source Code
 You can download ZAP enabled with the HUD from any of: 
 
 1. Download and run the latest [ZAP Weekly Release](https://github.com/zaproxy/zaproxy/wiki/Downloads#zap-weekly)
@@ -35,6 +37,34 @@ In all cases you will need Java 8+ installed.
 You'll see the HUD Radar icon ![Radar Icon](https://raw.githubusercontent.com/zaproxy/zap-hud/develop/src/main/resources/org/zaproxy/zap/extension/hud/resources/radar.png) in the tool bar. When the icon is selected the HUD will be added to your browser.
 
 ![Toolbar with Radar](https://raw.githubusercontent.com/zaproxy/zap-hud/develop/assets/images/toolbar_radar.png)
+
+#### Docker Compose
+Alternatively if you just want to run ZAP with zero setup and the HUD automatically installed and enabled with Docker you can use the included `docker-compose.yml` to start the environment in a Docker container.
+
+```
+    git clone https://github.com/zaproxy/zap-hud.git
+    cd zap-hud
+    cp .env.example .env
+```
+
+Create a random API key of your choosing and add it to your `.env` file
+```
+ZAP_API_KEY=somevalue
+```
+Start `docker-compose`
+
+```
+    docker-compose up
+```
+
+#### Docker
+If you'd like to run ZAP in a Docker container without cloning the repo, you can run the following `docker` command, swapping out `CHANGE_ME` with your custom API Key value:
+
+```
+docker run -u zap -p 9090:9090 --rm -i owasp/zap2docker-weekly zap.sh -daemon -host 0.0.0.0 -port 9090 \
+-config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -config -config api.key=CHANGE_ME \
+-config hud.enabledForDaemon=true
+```
 
 ### Starting the HUD
 1. Quick Start: Select either `Firefox` or `Chrome` on the `Quick Start` tab and click on the `Launch Browser` button.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  zap-hud:
+    image: owasp/zap2docker-weekly  
+    ports:
+      - 9090:9090
+    user: zap
+    env_file: 
+      - .env
+    command: >
+      sh -c "
+      zap.sh
+      -daemon
+      -host 0.0.0.0
+      -port 9090
+      -config api.addrs.addr.name=.*
+      -config api.addrs.addr.regex=true
+      -config api.key=${ZAP_API_KEY}
+      -config hud.enabledForDaemon=true"


### PR DESCRIPTION
Added simple `docker-compose` file for easily running the project in a Docker container with minimal setup and command line interaction.

Could add explicit `docker network` to run on, not sure if anyone has an opinion on that or use the default that will be created.