### PR TITLE
Remove HUD add-on bundled in the downloaded ZAP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -168,6 +168,7 @@ tasks {
                 into(zapInstallDir)
                 includeEmptyDirs = false
             }
+            delete(fileTree(zapInstallDir.dir("plugin")) { include("${zapAddOn.addOnId.get()}-*.zap") })
         }
     }
 
@@ -198,7 +199,7 @@ tasks {
         description = "Uninstalls the add-on from ZAP (started with \"runZap\")."
         addOnId.set(zapAddOn.addOnId)
     }
-    assembleZapAddOn.configure { mustRunAfter(uninstallAddOn) }
+    assembleZapAddOn.configure { mustRunAfter(uninstallAddOn, "zapDownload") }
 
     register<ZapInstallAddOn>("installAddOn") {
         group = AddOnPlugin.ADD_ON_GROUP


### PR DESCRIPTION
Change the `zapDownload` task to delete the HUD add-on bundled in ZAP to
ensure it's used always the local built one (in case of newer version in
the weekly). Also, change the `assembleZapAddOn` task to execute after
the `zapDownload` task to ensure the built add-on has a newer timestamp
(if same version ZAP loads the latest built add-on).