### PR TITLE
Feature/segment telemetry [WIP]

### DIFF
--- a/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -67,11 +67,11 @@ public class HudAPI extends ApiImplementor {
 
     // TODO shouldnt allow unsafe-inline styles - need to work out where they are being used
     protected static final String CSP_POLICY =
-            "default-src 'none'; script-src 'self'; connect-src https://zap wss://zap; frame-src 'self'; img-src 'self' data:; "
+            "default-src 'none'; script-src https://zap https://cdn.segment.com; connect-src https://zap wss://zap https://api.segment.io; frame-src 'self'; img-src 'self' data:; "
                     + "font-src 'self' data:; style-src 'self' 'unsafe-inline' ;";
 
     protected static final String CSP_POLICY_UNSAFE_EVAL =
-            "default-src 'none'; script-src 'self' 'unsafe-eval'; connect-src https://zap wss://zap; frame-src 'self'; img-src 'self' data:; "
+            "default-src 'none'; script-src https://zap https://cdn.segment.com 'unsafe-eval'; connect-src https://zap wss://zap https://api.segment.io; frame-src 'self'; img-src 'self' data:; "
                     + "font-src 'self' data:; style-src 'self' 'unsafe-inline' ;";
 
     private static final String PREFIX = "hud";

--- a/src/main/zapHomeFiles/hud/drawer.js
+++ b/src/main/zapHomeFiles/hud/drawer.js
@@ -250,6 +250,7 @@ Vue.component('tabs', {
             if (!this.isOpen) {
                 this.openDrawer();
                 selectedTab.badgeData = 0;
+			    analytics.track('ToolButtonClicked', {name: selectedTab.name}, { context: { ip: "0.0.0.0" }})
             }
             else {
                 if (selectedTab.isActive) {
@@ -267,6 +268,7 @@ Vue.component('tabs', {
                 tab.isActive = (tab.href == href);
                 if (tab.isActive) {
                 	tab.badgeData = 0;
+			        analytics.track('ToolButtonClicked', {name: tab.name}, { context: { ip: "0.0.0.0" }})
                 }
             });
         }
@@ -356,6 +358,7 @@ Vue.component('drawer-button-settings', {
     methods: {
         showHudSettings() {
             navigator.serviceWorker.controller.postMessage({tabId: tabId, frameId: frameId, action:'showHudSettings'});
+			analytics.track('SettingsOpened', { context: { ip: "0.0.0.0" }})
         }
     }
 });
@@ -376,6 +379,7 @@ Vue.component('drawer-button-showhide', {
             localforage.setItem('settings.isHudVisible', true)
                 .catch(utils.errorHandler);
 			parent.postMessage({tabId: tabId, frameId: frameId, action:'showSidePanels'}, document.referrer);
+			analytics.track('ButtonsShown', {}, { context: { ip: "0.0.0.0" }})
         },
         hideHud() {
             this.isHudVisible = false;
@@ -383,6 +387,7 @@ Vue.component('drawer-button-showhide', {
             localforage.setItem('settings.isHudVisible', false)
                 .catch(utils.errorHandler);
 			parent.postMessage({tabId: tabId, frameId: frameId, action:'hideSidePanels'}, document.referrer);
+			analytics.track('ButtonsHid', {}. { context: { ip: "0.0.0.0" }})
         },
 		toggleIsVisible() {
             this.isHudVisible ? this.hideHud() : this.showHud();
@@ -412,8 +417,12 @@ document.addEventListener("DOMContentLoaded", () => {
 		el: '#app',
 		data: {
 
-		},
+        },
     });
+
+	// segment telemetry
+	utils.loadAnalytics();
+	analytics.track('FrameLoaded', {id: frameId}, { context: { ip: "0.0.0.0" }});
 });
 
 navigator.serviceWorker.addEventListener('message', event => {

--- a/src/main/zapHomeFiles/hud/drawer.js
+++ b/src/main/zapHomeFiles/hud/drawer.js
@@ -250,7 +250,6 @@ Vue.component('tabs', {
             if (!this.isOpen) {
                 this.openDrawer();
                 selectedTab.badgeData = 0;
-			    analytics.track('ToolButtonClicked', {name: selectedTab.name}, { context: { ip: "0.0.0.0" }})
             }
             else {
                 if (selectedTab.isActive) {
@@ -267,8 +266,11 @@ Vue.component('tabs', {
             this.tabs.forEach(tab => {
                 tab.isActive = (tab.href == href);
                 if (tab.isActive) {
-                	tab.badgeData = 0;
-			        analytics.track('ToolButtonClicked', {name: tab.name}, { context: { ip: "0.0.0.0" }})
+                    tab.badgeData = 0;
+                    
+                    if (this.isOpen) {
+			            analytics.track('ToolButtonClicked', {name: tab.name}, { context: { ip: "0.0.0.0" }})
+                    }
                 }
             });
         }
@@ -387,7 +389,7 @@ Vue.component('drawer-button-showhide', {
             localforage.setItem('settings.isHudVisible', false)
                 .catch(utils.errorHandler);
 			parent.postMessage({tabId: tabId, frameId: frameId, action:'hideSidePanels'}, document.referrer);
-			analytics.track('ButtonsHid', {}. { context: { ip: "0.0.0.0" }})
+			analytics.track('ButtonsHid', {}, { context: { ip: "0.0.0.0" }})
         },
 		toggleIsVisible() {
             this.isHudVisible ? this.hideHud() : this.showHud();

--- a/src/main/zapHomeFiles/hud/management.js
+++ b/src/main/zapHomeFiles/hud/management.js
@@ -103,6 +103,17 @@ document.addEventListener('DOMContentLoaded', () => {
 		navigator.serviceWorker.controller.postMessage({action: 'targetload', tabId: tabId, targetUrl: context.url});
 
 		startHeartBeat();
+
+		// segment telemetry
+		utils.loadAnalytics();
+
+		localforage.getItem('starttime')
+			.then(startT => {
+				let currentTime = new Date().getTime();
+				let diff = currentTime - parseInt(startT);
+
+				analytics.track('FrameLoaded', {id: frameId, timeToLoad: diff }, { context: { ip: "0.0.0.0" }});
+			})
 	}
 });
 

--- a/src/main/zapHomeFiles/hud/panel.js
+++ b/src/main/zapHomeFiles/hud/panel.js
@@ -55,6 +55,10 @@ Vue.component('hud-button', {
 				panelKey: panelKey,
 				frameId: frameId,
 				tabId: tabId});
+
+			if (this.name !== 'add-tool') {
+				analytics.track("ToolButtonClicked", {tool: this.name}, { context: { ip: "0.0.0.0" }})
+			}
 		},
 		showContextMenu(event) {
 			event.preventDefault();
@@ -211,6 +215,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
 		}
 	}); 
+
+	// segment telemetry
+	utils.loadAnalytics();
+	analytics.track('FrameLoaded', {id: frameId}, { context: { ip: "0.0.0.0" }});
 });
 
 function doesContextApply(toolContext) {
@@ -261,6 +269,7 @@ navigator.serviceWorker.addEventListener("message", event => {
 				tool: tool
 			});
 
+			analytics.track('ToolAdded', {name: tool.name}, { context: { ip: "0.0.0.0" }})
 			break;
 
 		case "removeTool":
@@ -269,6 +278,8 @@ navigator.serviceWorker.addEventListener("message", event => {
 			eventBus.$emit('removeButton', {
 				name: tool.name
 			});
+
+			analytics.track('ToolRemoved', {name: tool.name}, { context: { ip: "0.0.0.0" }})
 			break;
 
 		default:

--- a/src/main/zapHomeFiles/hud/serviceworker.js
+++ b/src/main/zapHomeFiles/hud/serviceworker.js
@@ -83,23 +83,6 @@ const onActivate = event => {
 	);
 };
 
-// if we remove cache we can remove this as well
-const onFetch = event => {
-
-	event.respondWith(
-		caches.match(event.request)
-			.then(response => {  
-
-				if (response) {
-					return response;
-				}
-				else {
-					return fetch(event.request);
-				}
-			}).catch(utils.errorHandler)
-	);
-};
-
 const onMessage = event => {
 	if (!utils.isFromTrustedOrigin(event)) {
 		return;
@@ -157,7 +140,6 @@ const logHandler = event => {
 
 self.addEventListener("install", onInstall); 
 self.addEventListener("activate", onActivate);
-self.addEventListener("fetch", onFetch);
 self.addEventListener("message", onMessage);
 self.addEventListener('error', utils.errorHandler);
 self.addEventListener('hud.log', logHandler);

--- a/src/main/zapHomeFiles/hud/utils.js
+++ b/src/main/zapHomeFiles/hud/utils.js
@@ -640,6 +640,17 @@ var utils = (function() {
 			})
 			.catch(errorHandler)
 	}
+
+	/*
+	 * Loads the Segment analytics library for telemetry.
+	 */
+	function loadAnalytics() {
+		!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+			// public write-only key for segment analytics
+			analytics.load("gWdJpKHr0tdlE5inzWqL0RwdOkGfwF5u");
+			console.log('loaded analytics!')
+		}}();
+	}
 	
 	/*
 	 * Log an error in a human readable way with a stack trace.
@@ -734,6 +745,7 @@ return {
 		sortToolsByPosition: sortToolsByPosition,
 		configureButtonHtml: configureButtonHtml,
 		getUpgradedDomain: getUpgradedDomain,
+		loadAnalytics: loadAnalytics,
 		errorHandler: errorHandler,
 		getZapFilePath: getZapFilePath,
 		getZapImagePath: getZapImagePath,


### PR DESCRIPTION
I need to edit the ZAP event bus to ignore analytics messages going to segment.io. Intercepted messages and history get blown up with analytics calls.

Working on getting the segment account bumped up a couple tiers for free, then I can invite y'all to the workspace.

There are also a few pieces of info that are included by default, that I'm trying to remove. Namely, userAgent and referer (target site). Once those two pieces of information are removed everything should be good to go!