### PR TITLE
Add telemetry option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Telemetry config option (no telemetry yet)
 
+### Changed
+- To use ZAP 2.9.0 jar for access to the latest features
 
 ## [0.10.0] - 2020-02-04
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ zapAddOn {
     addOnName.set("HUD - Heads Up Display")
     addOnStatus.set(AddOnStatus.BETA)
 
-    zapVersion.set("2.8.0")
+    zapVersion.set("2.9.0")
 
     releaseLink.set("https://github.com/zaproxy/zap-hud/compare/v@PREVIOUS_VERSION@...v@CURRENT_VERSION@")
     unreleasedLink.set("https://github.com/zaproxy/zap-hud/compare/v@CURRENT_VERSION@...HEAD")

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "type": "git",
     "url": "git+https://github.com/zaproxy/zap-hud.git"
   },
-  "author": "David Scrobonia",
+  "author": "ZAP Core Team",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/zaproxy/zap-hud/issues"

--- a/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -186,7 +186,7 @@ public class ExtensionHUD extends ExtensionAdaptor
 
     @Override
     public void unload() {
-        getExtScript().removeScripType(hudScriptType);
+        getExtScript().removeScriptType(hudScriptType);
         getExtScript().removeListener(this);
 
         HudEventPublisher.unregister();

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudParam.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudParam.java
@@ -68,6 +68,7 @@ public class HudParam extends VersionedAbstractParam {
     private static final String PARAM_ENABLE_ON_DOMAIN_MSGS =
             PARAM_BASE_KEY + ".enableOnDomainMsgs";
     private static final String PARAM_UI_OPTION_PREFIX = PARAM_BASE_KEY + ".uiOption.";
+    private static final String PARAM_ENABLE_TELEMETRY = PARAM_BASE_KEY + ".enableTelemetry";
 
     /**
      * The version of the configurations. Used to keep track of configurations changes between
@@ -103,6 +104,8 @@ public class HudParam extends VersionedAbstractParam {
     private boolean showWelcomeScreen;
 
     private boolean enableOnDomainMsgs;
+
+    private boolean enableTelemetry;
 
     private List<String> tutorialTasks;
 
@@ -234,6 +237,15 @@ public class HudParam extends VersionedAbstractParam {
         getConfig().setProperty(PARAM_ENABLE_ON_DOMAIN_MSGS, enableOnDomainMsgs);
     }
 
+    public boolean isEnableTelemetry() {
+        return enableTelemetry;
+    }
+
+    public void setEnableTelemetry(boolean enableTelemetry) {
+        this.enableTelemetry = enableTelemetry;
+        getConfig().setProperty(PARAM_ENABLE_TELEMETRY, enableTelemetry);
+    }
+
     @Override
     protected String getConfigVersionKey() {
         return PARAM_BASE_KEY + VERSION_ATTRIBUTE;
@@ -269,6 +281,9 @@ public class HudParam extends VersionedAbstractParam {
         showWelcomeScreen = getConfig().getBoolean(PARAM_SHOW_WELCOME_SCREEN, true);
         newChangelog = getConfig().getBoolean(PARAM_NEW_CHANGELOG, false);
         enableOnDomainMsgs = getConfig().getBoolean(PARAM_ENABLE_ON_DOMAIN_MSGS, true);
+        enableTelemetry =
+                !Constant.isSilent()
+                        && getConfig().getBoolean(PARAM_ENABLE_TELEMETRY, !Constant.isDevMode());
     }
 
     private List<String> convert(List<Object> objs) {

--- a/src/main/java/org/zaproxy/zap/extension/hud/OptionsHudPanel.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/OptionsHudPanel.java
@@ -51,6 +51,7 @@ public class OptionsHudPanel extends AbstractParamPanel {
     private JTextField baseDirectory;
     private JCheckBox enabledForDesktop = null;
     private JCheckBox enabledForDaemon = null;
+    private JCheckBox enableTelemetry = null;
     private JCheckBox inScopeOnly = null;
     private JCheckBox enableOnDomainMsgs = null;
     private JCheckBox showWelcomeScreen = null;
@@ -83,6 +84,7 @@ public class OptionsHudPanel extends AbstractParamPanel {
         int i = 0;
         panel.add(getEnabledForDesktop(), LayoutHelper.getGBC(0, ++i, 2, 1.0));
         panel.add(getEnabledForDaemon(), LayoutHelper.getGBC(0, ++i, 2, 1.0));
+        panel.add(getEnableTelemetry(), LayoutHelper.getGBC(0, ++i, 2, 1.0));
         panel.add(getShowWelcomeScreen(), LayoutHelper.getGBC(0, ++i, 2, 1.0));
         panel.add(getInScopeOnly(), LayoutHelper.getGBC(0, ++i, 2, 1.0));
         panel.add(getEnableOnDomainMsgs(), LayoutHelper.getGBC(0, ++i, 2, 1.0));
@@ -121,6 +123,15 @@ public class OptionsHudPanel extends AbstractParamPanel {
                             Constant.messages.getString("hud.optionspanel.label.enabledForDaemon"));
         }
         return enabledForDaemon;
+    }
+
+    private JCheckBox getEnableTelemetry() {
+        if (enableTelemetry == null) {
+            enableTelemetry =
+                    new JCheckBox(
+                            Constant.messages.getString("hud.optionspanel.label.enableTelemetry"));
+        }
+        return enableTelemetry;
     }
 
     private JCheckBox getInScopeOnly() {
@@ -202,6 +213,7 @@ public class OptionsHudPanel extends AbstractParamPanel {
 
         getEnabledForDesktop().setSelected(param.isEnabledForDesktop());
         getEnabledForDaemon().setSelected(param.isEnabledForDaemon());
+        getEnableTelemetry().setSelected(param.isEnableTelemetry());
         getBaseDirectory().setText(param.getBaseDirectory());
         getInScopeOnly().setSelected(param.isInScopeOnly());
         getEnableOnDomainMsgs().setSelected(param.isEnableOnDomainMsgs());
@@ -248,6 +260,7 @@ public class OptionsHudPanel extends AbstractParamPanel {
 
         param.setEnabledForDesktop(getEnabledForDesktop().isSelected());
         param.setEnabledForDaemon(getEnabledForDaemon().isSelected());
+        param.setEnableTelemetry(getEnableTelemetry().isSelected());
         param.setBaseDirectory(getBaseDirectory().getText());
         param.setInScopeOnly(getInScopeOnly().isSelected());
         param.setEnableOnDomainMsgs(getEnableOnDomainMsgs().isSelected());

--- a/src/main/resources/org/zaproxy/zap/extension/hud/resources/Messages.properties
+++ b/src/main/resources/org/zaproxy/zap/extension/hud/resources/Messages.properties
@@ -37,6 +37,7 @@ hud.optionspanel.button.baseDirectory	= Change
 hud.optionspanel.label.baseDirectory	= Base Directory:
 hud.optionspanel.label.enabledForDesktop = Enable when using the ZAP Desktop
 hud.optionspanel.label.enabledForDaemon = Enable when using ZAP in daemon mode
+hud.optionspanel.label.enableTelemetry = Enable anonymous telemetry
 hud.optionspanel.label.enableOnDomainMsgs = Enable on-domain messages
 hud.optionspanel.label.inScopeOnly		= Enable the HUD only for URLs that are in scope
 hud.optionspanel.label.showWelcomeScreen = Show the HUD welcome screen when a browser is opened


### PR DESCRIPTION
Note that this does not actually add the telemetry!

@dscrobonia this also doesnt add any user information about the telemetry - I'm assuming your PR will do that :)
You can check the telemetry option via the API but right now there are no events to say when the telemetry option is changed - will you need those? Can add them in a future PR if they will be needed.