### PR TITLE
Enablers for new Quick Start tab

### DIFF
--- a/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -134,18 +135,12 @@ public class ExtensionHUD extends ExtensionAdaptor
 
     /** */
     public ExtensionHUD() {
-        super();
-        initialize();
+        this(NAME);
     }
 
     /** @param name */
     public ExtensionHUD(String name) {
         super(name);
-    }
-
-    /** This method initializes this */
-    private void initialize() {
-        this.setName(NAME);
     }
 
     @Override
@@ -229,12 +224,20 @@ public class ExtensionHUD extends ExtensionAdaptor
         tutorialServer.start();
     }
 
-    protected boolean isHudEnabled() {
+    public boolean isHudEnabled() {
         if (View.isInitialised()) {
             return hudEnabledForDesktop;
         } else {
             return hudEnabledForDaemon || this.hudCmdlineOptionUsed;
         }
+    }
+
+    public void setHudEnabledForDesktop(Boolean enabled) {
+        if (hudButton != null) {
+            hudButton.setSelected(enabled);
+        }
+        this.hudEnabledForDesktop = enabled;
+        getHudParam().setEnabledForDesktop(hudEnabledForDesktop);
     }
 
     /**
@@ -596,5 +599,9 @@ public class ExtensionHUD extends ExtensionAdaptor
 
     protected Set<String> getUpgradedHttpsDomains() {
         return upgradedHttpsDomains;
+    }
+
+    public List<String> getSupportedBrowserIds() {
+        return Arrays.asList("firefox", "chrome");
     }
 }

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudEventPublisher.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudEventPublisher.java
@@ -25,6 +25,10 @@ import org.zaproxy.zap.eventBus.EventPublisher;
 public class HudEventPublisher implements EventPublisher {
 
     private static HudEventPublisher publisher = null;
+    public static final String EVENT_ENABLED_FOR_DESKTOP = "desktop.enabled";
+    public static final String EVENT_DISABLED_FOR_DESKTOP = "desktop.disabled";
+    public static final String EVENT_ENABLED_FOR_DAEMON = "daemon.enabled";
+    public static final String EVENT_DISABLED_FOR_DAEMON = "daemon.disabled";
     public static final String EVENT_DEV_MODE_ENABLED = "devMode.enabled";
     public static final String EVENT_DEV_MODE_DISABLED = "devMode.disabled";
     public static final String EVENT_DOMAIN_UPGRADED_TO_HTTPS = "domain.upgraded";
@@ -44,6 +48,10 @@ public class HudEventPublisher implements EventPublisher {
                     .registerPublisher(
                             publisher,
                             new String[] {
+                                EVENT_ENABLED_FOR_DESKTOP,
+                                EVENT_DISABLED_FOR_DESKTOP,
+                                EVENT_ENABLED_FOR_DAEMON,
+                                EVENT_DISABLED_FOR_DAEMON,
                                 EVENT_DEV_MODE_ENABLED,
                                 EVENT_DEV_MODE_DISABLED,
                                 EVENT_DOMAIN_UPGRADED_TO_HTTPS,

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudParam.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudParam.java
@@ -24,7 +24,9 @@ import java.util.List;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.common.VersionedAbstractParam;
+import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.extension.api.ZapApiIgnore;
 
 public class HudParam extends VersionedAbstractParam {
@@ -129,6 +131,16 @@ public class HudParam extends VersionedAbstractParam {
     public void setEnabledForDesktop(boolean enabledForDesktop) {
         this.enabledForDesktop = enabledForDesktop;
         getConfig().setProperty(PARAM_ENABLED_DESKTOP, enabledForDesktop);
+        String event;
+        if (enabledForDesktop) {
+            event = HudEventPublisher.EVENT_ENABLED_FOR_DESKTOP;
+        } else {
+            event = HudEventPublisher.EVENT_DISABLED_FOR_DESKTOP;
+        }
+        ZAP.getEventBus()
+                .publishSyncEvent(
+                        HudEventPublisher.getPublisher(),
+                        new Event(HudEventPublisher.getPublisher(), event, null));
     }
 
     public boolean isEnabledForDaemon() {
@@ -138,6 +150,16 @@ public class HudParam extends VersionedAbstractParam {
     public void setEnabledForDaemon(boolean enabledForDaemon) {
         this.enabledForDaemon = enabledForDaemon;
         getConfig().setProperty(PARAM_ENABLED_DAEMON, enabledForDaemon);
+        String event;
+        if (enabledForDaemon) {
+            event = HudEventPublisher.EVENT_ENABLED_FOR_DAEMON;
+        } else {
+            event = HudEventPublisher.EVENT_DISABLED_FOR_DAEMON;
+        }
+        ZAP.getEventBus()
+                .publishSyncEvent(
+                        HudEventPublisher.getPublisher(),
+                        new Event(HudEventPublisher.getPublisher(), event, null));
     }
 
     public boolean isInScopeOnly() {


### PR DESCRIPTION
New methods and events to make it easier for other add-ons to interact with the HUD, in this case for the new ZAP Quick Start tab.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>