### PR TITLE
Remove ZapVersions configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,10 +73,6 @@ zapAddOn {
             }
         }
     }
-
-    zapVersions {
-        downloadUrl.set("https://github.com/zaproxy/zap-hud/releases/download/v$version")
-    }
 }
 
 val generateI18nJsFile by tasks.creating(GenerateI18nJsFile::class) {


### PR DESCRIPTION
The generation of the ZapVersions.xml data will be done in the zap-admin
repository when needed.