### PR TITLE
Update Gradle and add-on plugin

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,23 @@
+workflow "Release Add-On" {
+  on = "push"
+  resolves = ["Build and Release Add-On"]
+}
+
+action "Add-On Tag Filter" {
+  uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
+  args = "tag v*"
+}
+
+action "Actor Filter" {
+  uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
+  needs = ["Add-On Tag Filter"]
+  args = ["actor", "kingthorin", "psiinon", "thc202"]
+}
+
+action "Build and Release Add-On" {
+  uses = "docker://openjdk:8"
+  needs = ["Actor Filter"]
+  runs = "./gradlew"
+  args = "createReleaseFromGitHubRef"
+  secrets = ["GITHUB_TOKEN"]
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle to 5.4.1 and add-on plugin to 0.2.0.
Update build accordingly.
Add GitHub Actions workflow and Gradle task to release on tag.

---
WIP until zaproxy is updated (zaproxy/zaproxy#5369).