### PR TITLE
Fix tests with Firefox >= 67

### DIFF
--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/firefox/FirefoxUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/firefox/FirefoxUnitTest.java
@@ -49,6 +49,7 @@ public abstract class FirefoxUnitTest {
         this.firefoxOptions.addPreference("network.proxy.ssl_port", Constants.ZAP_PORT);
         this.firefoxOptions.addPreference("network.proxy.share_proxy_settings", true);
         this.firefoxOptions.addPreference("network.proxy.no_proxies_on", "");
+        this.firefoxOptions.addPreference("network.proxy.allow_hijacking_localhost", true);
         firefoxOptions.setCapability(CapabilityType.PROXY, (Object) null);
         firefoxOptions.setHeadless(true);
     }


### PR DESCRIPTION
Add preference to keep proxying localhost with newer Firefox versions.