### PR TITLE
Change to use openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 sudo: required
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 addons:


### PR DESCRIPTION
Hoping this will fix the build, which is currently failing as oraclejdk8 is no longer available.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>