### PR TITLE
Use newer ZAP version for compilation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,8 +94,6 @@ java {
 val jupiterVersion = "5.3.1"
 
 dependencies {
-    zap("org.zaproxy:zap:2.7.0")
-
     compileOnly(files(fileTree("lib").files))
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")


### PR DESCRIPTION
Use 2.8.0 instead of 2.7.0.