### PR TITLE
Access files by path instead of query

### DIFF
--- a/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -185,22 +185,22 @@ public class HudAPI extends ApiImplementor {
     public String handleCallBack(HttpMessage msg) throws ApiException {
         // Just used to handle files which need to be on the target domain
         try {
-            String query = msg.getRequestHeader().getURI().getPathQuery();
-            logger.debug("callback query = " + query);
-            if (query != null) {
-                if (query.indexOf("zapfile=") > 0) {
-                    String fileName = query.substring(query.indexOf("zapfile=") + 8);
-                    if (DOMAIN_FILE_WHITELIST.contains(fileName)) {
-                        msg.setResponseBody(
-                                this.getFile(msg, ExtensionHUD.TARGET_DIRECTORY + "/" + fileName));
-                        // Currently only javascript files are returned
-                        msg.setResponseHeader(
-                                API.getDefaultResponseHeader(
-                                        "application/javascript; charset=UTF-8",
-                                        msg.getResponseBody().length(),
-                                        false));
-                        return msg.getResponseBody().toString();
-                    }
+            String path = msg.getRequestHeader().getURI().getEscapedPath();
+            int lastSlash = path.lastIndexOf("/");
+            String fileName = path.substring(lastSlash + 1);
+
+            logger.debug("callback fileName = " + fileName);
+            if (fileName != null) {
+                if (DOMAIN_FILE_WHITELIST.contains(fileName)) {
+                    msg.setResponseBody(
+                            this.getFile(msg, ExtensionHUD.TARGET_DIRECTORY + "/" + fileName));
+                    // Currently only javascript files are returned
+                    msg.setResponseHeader(
+                            API.getDefaultResponseHeader(
+                                    "application/javascript; charset=UTF-8",
+                                    msg.getResponseBody().length(),
+                                    false));
+                    return msg.getResponseBody().toString();
                 }
             }
         } catch (Exception e) {
@@ -458,7 +458,7 @@ public class HudAPI extends ApiImplementor {
                         if (tool.toLowerCase(Locale.ROOT).endsWith(".js")) {
                             sb.append("\t\"");
                             sb.append(this.hudFileUrl);
-                            sb.append("?name=tools/");
+                            sb.append("/file/tools/");
                             sb.append(tool);
                             sb.append("\",\n");
                         }

--- a/src/main/zapHomeFiles/hud/display.html
+++ b/src/main/zapHomeFiles/hud/display.html
@@ -1,14 +1,14 @@
 <html>
     <head>   
-        <link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=libraries/spectre.css"/>
-        <link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=libraries/spectre-icons.css"/>
-        <link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=display.css"/>
+        <link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>/file/libraries/spectre.css"/>
+        <link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>/file/libraries/spectre-icons.css"/>
+        <link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>/file/display.css"/>
 
-        <script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=libraries/vue.js"></script>
-        <script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=libraries/vue-i18n.js"></script>
-        <script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=i18n.js"></script>
-        <script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=utils.js"></script>
-        <script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=display.js"></script>
+        <script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/libraries/vue.js"></script>
+        <script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/libraries/vue-i18n.js"></script>
+        <script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/i18n.js"></script>
+        <script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/utils.js"></script>
+        <script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/display.js"></script>
     </head>
 
     <body>
@@ -266,9 +266,9 @@
                 <div slot="body">
                     <ul class="menu">
                         <li v-for="(conf, id) in items" class="menu-item" @click="itemSelect(id)">
-                            <img v-if="conf.startimage"  :src="'<<ZAP_HUD_FILES>>?image=' + conf.startimage" />
+                            <img v-if="conf.startimage"  :src="'<<ZAP_HUD_FILES>>/image/' + conf.startimage" />
                             {{ conf.label }}
-                            <img v-if="conf.endimage"  :src="'<<ZAP_HUD_FILES>>?image=' + conf.endimage" />
+                            <img v-if="conf.endimage"  :src="'<<ZAP_HUD_FILES>>/image/' + conf.endimage" />
                         </li>
                     </ul>
                 </div>
@@ -312,7 +312,7 @@
                 <div slot="footer">
                 	<div><span class="errorMessages">{{errors}}</span></div>
                 	<div class="float-left">
-                    <button :class="{'btn': true, 'disabled': isAscanDisabled}" @click="ascanRequest"> {{ $t('message.history_ascan_request') }} <img src="<<ZAP_HUD_FILES>>?image=flame.png" /> </button>
+                    <button :class="{'btn': true, 'disabled': isAscanDisabled}" @click="ascanRequest"> {{ $t('message.history_ascan_request') }} <img src="<<ZAP_HUD_FILES>>/image/flame.png" /> </button>
                     </div>
                     <button class="btn btn-primary" @click="replay"> {{ $t('message.history_replay_console') }} </button>
                     <button class="btn" @click="replayInBrowser"> {{ $t('message.history_replay_browser') }} </button>

--- a/src/main/zapHomeFiles/hud/drawer.html
+++ b/src/main/zapHomeFiles/hud/drawer.html
@@ -1,15 +1,15 @@
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=libraries/spectre.css"/>
-	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=libraries/spectre-icons.css"/>
-    <link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=drawer.css"/>
+	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>/file/libraries/spectre.css"/>
+	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>/file/libraries/spectre-icons.css"/>
+    <link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>/file/drawer.css"/>
 
-	<script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=libraries/localforage.min.js"></script>
-	<script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=libraries/vue.js"></script>
-	<script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=libraries/vue-i18n.js"></script>
-	<script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=i18n.js"></script>
-	<script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=utils.js"></script>
-	<script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=drawer.js"></script>
+	<script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/libraries/localforage.min.js"></script>
+	<script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/libraries/vue.js"></script>
+	<script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/libraries/vue-i18n.js"></script>
+	<script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/i18n.js"></script>
+	<script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/utils.js"></script>
+	<script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/drawer.js"></script>
 </head>
 <body>
     <div id="app">

--- a/src/main/zapHomeFiles/hud/growlerAlerts.html
+++ b/src/main/zapHomeFiles/hud/growlerAlerts.html
@@ -1,9 +1,9 @@
 <html>
 <head>
-	<script src="<<ZAP_HUD_FILES>>?name=libraries/alertify.js"></script>
-	<script src="<<ZAP_HUD_FILES>>?name=libraries/localforage.min.js"></script>
-	<script src="<<ZAP_HUD_FILES>>?name=utils.js"></script>
-	<script src="<<ZAP_HUD_FILES>>?name=growlerAlerts.js"></script>
+	<script src="<<ZAP_HUD_FILES>>/file/libraries/alertify.js"></script>
+	<script src="<<ZAP_HUD_FILES>>/file/libraries/localforage.min.js"></script>
+	<script src="<<ZAP_HUD_FILES>>/file/utils.js"></script>
+	<script src="<<ZAP_HUD_FILES>>/file/growlerAlerts.js"></script>
 </head>
 <body>
 

--- a/src/main/zapHomeFiles/hud/growlerAlerts.js
+++ b/src/main/zapHomeFiles/hud/growlerAlerts.js
@@ -1,10 +1,10 @@
 // Injected string
 var ZAP_HUD_FILES = '<<ZAP_HUD_FILES>>';
 
-var INFORMATIONAL_FLAG = '<img src="' + ZAP_HUD_FILES + '?image=flag-blue.png" >&nbsp';
-var LOW_FLAG = '<img src="' + ZAP_HUD_FILES + '?image=flag-yellow.png" >&nbsp';
-var MEDIUM_FLAG = '<img src="' + ZAP_HUD_FILES + '?image=flag-orange.png" >&nbsp';
-var HIGH_FLAG = '<img src="' + ZAP_HUD_FILES + '?image=flag-red.png" >&nbsp';
+var INFORMATIONAL_FLAG = '<img src="' + ZAP_HUD_FILES + '/image/flag-blue.png" >&nbsp';
+var LOW_FLAG = '<img src="' + ZAP_HUD_FILES + '/image/flag-yellow.png" >&nbsp';
+var MEDIUM_FLAG = '<img src="' + ZAP_HUD_FILES + '/image/flag-orange.png" >&nbsp';
+var HIGH_FLAG = '<img src="' + ZAP_HUD_FILES + '/image/flag-red.png" >&nbsp';
 var DELAY_MS = 3000;
 var QUEUE_SIZE = 5;
 var MAX_LINE_LENGTH = 45;

--- a/src/main/zapHomeFiles/hud/management.html
+++ b/src/main/zapHomeFiles/hud/management.html
@@ -1,12 +1,12 @@
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=libraries/spectre.css"/>
-	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=management.css" />
+	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>/file/libraries/spectre.css"/>
+	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>/file/management.css" />
 
-	<script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=libraries/vue.js"></script>
-	<script src="<<ZAP_HUD_FILES>>?name=libraries/localforage.min.js"></script>
-	<script src="<<ZAP_HUD_FILES>>?name=utils.js"></script>
-	<script src="<<ZAP_HUD_FILES>>?name=management.js"></script>
+	<script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/libraries/vue.js"></script>
+	<script src="<<ZAP_HUD_FILES>>/file/libraries/localforage.min.js"></script>
+	<script src="<<ZAP_HUD_FILES>>/file/utils.js"></script>
+	<script src="<<ZAP_HUD_FILES>>/file/management.js"></script>
 </head>
 <body>
 	<div id="app"> 
@@ -15,7 +15,7 @@
 
 	<template id="welcome-screen-template">
 		<div class="welcome-div">
-			<img class="welcome-image" src='<<ZAP_HUD_FILES>>?image=hud-welcome.png'>
+			<img class="welcome-image" src='<<ZAP_HUD_FILES>>/image/hud-welcome.png'>
 			<div class="tutorial-div">
 				<button class="btn btn-primary" @click="continueToTutorial"> Take the HUD Tutorial </button>
 			</div>

--- a/src/main/zapHomeFiles/hud/panel.html
+++ b/src/main/zapHomeFiles/hud/panel.html
@@ -1,12 +1,12 @@
 <html>
 <head>
-	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=libraries/spectre.css"/>
-	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>?name=panel.css&amp;orientation=ORIENTATION" />
+	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>/file/libraries/spectre.css"/>
+	<link rel="stylesheet" type="text/css" href="<<ZAP_HUD_FILES>>/file/panel.css?orientation=ORIENTATION" />
 
-	<script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=libraries/localforage.min.js"></script>
-	<script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=libraries/vue.js"></script>
-	<script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=utils.js"></script>
-	<script type="text/javascript" src="<<ZAP_HUD_FILES>>?name=panel.js"></script>
+	<script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/libraries/localforage.min.js"></script>
+	<script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/libraries/vue.js"></script>
+	<script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/utils.js"></script>
+	<script type="text/javascript" src="<<ZAP_HUD_FILES>>/file/panel.js"></script>
 </head>
 <body>
 	<div id="app">
@@ -15,8 +15,8 @@
 
 	<template id="hud-buttons-template">
 		<div id="hud-buttons" :class="{'d-hide': !isVisible, 'd-visible': isVisible}">
-			<hud-button v-for="tool in tools" :key="tool.name" :label="tool.label" :icon="'<<ZAP_HUD_FILES>>?image=' + tool.icon" :data="tool.data" :name="tool.name"></hud-button>
-			<hud-button icon="<<ZAP_HUD_FILES>>?image=plus.png" name="add-tool"></hud-button>
+			<hud-button v-for="tool in tools" :key="tool.name" :label="tool.label" :icon="'<<ZAP_HUD_FILES>>/image/' + tool.icon" :data="tool.data" :name="tool.name"></hud-button>
+			<hud-button icon="<<ZAP_HUD_FILES>>/image/plus.png" name="add-tool"></hud-button>
 		</div>
 	</template>
 

--- a/src/main/zapHomeFiles/hud/panel.js
+++ b/src/main/zapHomeFiles/hud/panel.js
@@ -4,7 +4,7 @@
  * Description goes here...
  */
 
-var IMAGE_URL = '<<ZAP_HUD_FILES>>?image=';
+var IMAGE_URL = '<<ZAP_HUD_FILES>>/image/';
 var orientation = "";
 var panelKey = "";
 var frameId = '';

--- a/src/main/zapHomeFiles/hud/serviceworker.js
+++ b/src/main/zapHomeFiles/hud/serviceworker.js
@@ -8,12 +8,12 @@ var CONFIG_TOOLS_LEFT = '<<ZAP_HUD_CONFIG_TOOLS_LEFT>>';
 var CONFIG_TOOLS_RIGHT = '<<ZAP_HUD_CONFIG_TOOLS_RIGHT>>';
 var CONFIG_DRAWER = '<<ZAP_HUD_CONFIG_DRAWER>>';
 
-importScripts(ZAP_HUD_FILES + "?name=libraries/localforage.min.js"); 
-importScripts(ZAP_HUD_FILES + "?name=libraries/vue.js"); 
-importScripts(ZAP_HUD_FILES + "?name=libraries/vue-i18n.js"); 
-importScripts(ZAP_HUD_FILES + "?name=i18n.js");
-importScripts(ZAP_HUD_FILES + "?name=utils.js");
-importScripts(ZAP_HUD_FILES + "?name=tools/utils/alertUtils.js");
+importScripts(ZAP_HUD_FILES + "/file/libraries/localforage.min.js"); 
+importScripts(ZAP_HUD_FILES + "/file/libraries/vue.js"); 
+importScripts(ZAP_HUD_FILES + "/file/libraries/vue-i18n.js"); 
+importScripts(ZAP_HUD_FILES + "/file/i18n.js");
+importScripts(ZAP_HUD_FILES + "/file/utils.js");
+importScripts(ZAP_HUD_FILES + "/file/tools/utils/alertUtils.js");
 
 var CACHE_NAME = "hud-cache-1.0";
 var targetUrl = "";
@@ -22,22 +22,22 @@ var webSocketCallbacks = {};
 var webSocketCallbackId = 0;
 
 var urlsToCache = [
-	ZAP_HUD_FILES + "?name=libraries/localforage.min.js",
-	ZAP_HUD_FILES + "?name=libraries/vue.js",
-	ZAP_HUD_FILES + "?name=libraries/vue-i18n.js",
-	ZAP_HUD_FILES + "?name=i18n.js",
-	ZAP_HUD_FILES + "?name=utils.js",
-	ZAP_HUD_FILES + "?name=panel.html",
-	ZAP_HUD_FILES + "?name=panel.css",
-	ZAP_HUD_FILES + "?name=panel.js",
-	ZAP_HUD_FILES + "?name=display.css",
-	ZAP_HUD_FILES + "?name=display.html",
-	ZAP_HUD_FILES + "?name=display.js",
-	ZAP_HUD_FILES + "?name=management.css",
-	ZAP_HUD_FILES + "?name=management.html",
-	ZAP_HUD_FILES + "?name=management.js",
-	ZAP_HUD_FILES + "?name=growlerAlerts.html",
-	ZAP_HUD_FILES + "?name=growlerAlerts.js"
+	ZAP_HUD_FILES + "/file/libraries/localforage.min.js",
+	ZAP_HUD_FILES + "/file/libraries/vue.js",
+	ZAP_HUD_FILES + "/file/libraries/vue-i18n.js",
+	ZAP_HUD_FILES + "/file/i18n.js",
+	ZAP_HUD_FILES + "/file/utils.js",
+	ZAP_HUD_FILES + "/file/panel.html",
+	ZAP_HUD_FILES + "/file/panel.css",
+	ZAP_HUD_FILES + "/file/panel.js",
+	ZAP_HUD_FILES + "/file/display.css",
+	ZAP_HUD_FILES + "/file/display.html",
+	ZAP_HUD_FILES + "/file/display.js",
+	ZAP_HUD_FILES + "/file/management.css",
+	ZAP_HUD_FILES + "/file/management.html",
+	ZAP_HUD_FILES + "/file/management.js",
+	ZAP_HUD_FILES + "/file/growlerAlerts.html",
+	ZAP_HUD_FILES + "/file/growlerAlerts.js"
 ];
 
 self.tools = {};
@@ -275,7 +275,7 @@ function showAddToolDialog(tabId, frameId) {
 	
 			tools = tools.map(tool => ({
                 'label': tool.label,
-                'image': ZAP_HUD_FILES + '?image=' + tool.icon,
+                'image': ZAP_HUD_FILES + '/image/' + tool.icon,
                 'toolname': tool.name
             }));
 

--- a/src/main/zapHomeFiles/hud/target/inject.js
+++ b/src/main/zapHomeFiles/hud/target/inject.js
@@ -298,7 +298,7 @@
 			let colour = colours[alert.risk];
 			el.style.borderColor = colour || 'red';
 			el.insertAdjacentHTML('afterend',
-				'<img src="' + ZAP_HUD_FILES + '?image=flag-' + colour + '.png" ' +
+				'<img src="' + ZAP_HUD_FILES + '/image/flag-' + colour + '.png" ' +
 				'id="zapHudAlert-' + alert.id + '" ' +
 				'title="' + alert.name + '" height="16" width="16" ' +
 				'onclick="injection.showZapAlert(' + alert.id + ');" />');
@@ -437,12 +437,12 @@
 
 		var template = document.createElement("template");
 		template.innerHTML = 
-			'<iframe id="' + MANAGEMENT + '" src="' + ZAP_HUD_FILES + '?name=management.html&amp;frameId=management&amp;tabId=' + tabId + '" scrolling="no" style="position: fixed; right: 0px; bottom: 50px; width:28px; height:60px; border: medium none; overflow: hidden; z-index: 2147483647"></iframe>\n' +
-			'<iframe id="' + LEFT_PANEL + '" src="' + ZAP_HUD_FILES + '?name=panel.html&amp;url=' + URL + '&amp;orientation=left&amp;frameId=leftPanel&amp;tabId=' + tabId + '" scrolling="no" style="position: fixed; border: medium none; top: 30%; border: medium none; left: 0px; width: 110px; height: 300px; z-index: 2147483646;"></iframe>\n' +
-			'<iframe id="' + RIGHT_PANEL + '" src="' + ZAP_HUD_FILES + '?name=panel.html&amp;url=' + URL + '&amp;orientation=right&amp;frameId=rightPanel&amp;tabId=' + tabId + '" scrolling="no" style="position: fixed; border: medium none; top: 30%; overflow: hidden; right: 0px; width: 110px; height: 300px; z-index: 2147483646;"></iframe>\n' +
-			'<iframe id="' + BOTTOM_DRAWER + '" src="' + ZAP_HUD_FILES + '?name=drawer.html&amp;frameId=drawer&amp;tabId=' + tabId + '" scrolling="no" style="position: fixed; border: medium none; overflow: hidden; left: 0px; bottom: 0px; width: 100%; height: 50px; z-index: 2147483646;"></iframe>\n' +
-			'<iframe id="' + MAIN_DISPLAY + '" src="' + ZAP_HUD_FILES + '?name=display.html&amp;frameId=display&amp;tabId=' + tabId + '" style="position: fixed; right: 0px; top: 0px; width: 100%; height: 100%; border: 0px none; display: none; z-index: 2147483647;"></iframe>\n' +
-			'<iframe id="' + GROWLER_ALERTS + '" src="' + ZAP_HUD_FILES + '?name=growlerAlerts.html&amp;frameId=growlerAlerts&amp;tabId=' + tabId + '" style="position: fixed; right: 0px; bottom: 30px; width: 500px; height: 0px;border: 0px none; z-index: 2147483647;"></iframe>';
+			'<iframe id="' + MANAGEMENT + '" src="' + ZAP_HUD_FILES + '/file/management.html?frameId=management&amp;tabId=' + tabId + '" scrolling="no" style="position: fixed; right: 0px; bottom: 50px; width:28px; height:60px; border: medium none; overflow: hidden; z-index: 2147483647"></iframe>\n' +
+			'<iframe id="' + LEFT_PANEL + '" src="' + ZAP_HUD_FILES + '/file/panel.html?url=' + URL + '&amp;orientation=left&amp;frameId=leftPanel&amp;tabId=' + tabId + '" scrolling="no" style="position: fixed; border: medium none; top: 30%; border: medium none; left: 0px; width: 110px; height: 300px; z-index: 2147483646;"></iframe>\n' +
+			'<iframe id="' + RIGHT_PANEL + '" src="' + ZAP_HUD_FILES + '/file/panel.html?url=' + URL + '&amp;orientation=right&amp;frameId=rightPanel&amp;tabId=' + tabId + '" scrolling="no" style="position: fixed; border: medium none; top: 30%; overflow: hidden; right: 0px; width: 110px; height: 300px; z-index: 2147483646;"></iframe>\n' +
+			'<iframe id="' + BOTTOM_DRAWER + '" src="' + ZAP_HUD_FILES + '/file/drawer.html?frameId=drawer&amp;tabId=' + tabId + '" scrolling="no" style="position: fixed; border: medium none; overflow: hidden; left: 0px; bottom: 0px; width: 100%; height: 50px; z-index: 2147483646;"></iframe>\n' +
+			'<iframe id="' + MAIN_DISPLAY + '" src="' + ZAP_HUD_FILES + '/file/display.html?frameId=display&amp;tabId=' + tabId + '" style="position: fixed; right: 0px; top: 0px; width: 100%; height: 100%; border: 0px none; display: none; z-index: 2147483647;"></iframe>\n' +
+			'<iframe id="' + GROWLER_ALERTS + '" src="' + ZAP_HUD_FILES + '/file/growlerAlerts.html?frameId=growlerAlerts&amp;tabId=' + tabId + '" style="position: fixed; right: 0px; bottom: 30px; width: 500px; height: 0px;border: 0px none; z-index: 2147483647;"></iframe>';
 		document.body.appendChild(template.content);
 		document.body.style.marginBottom = "50px";
 		

--- a/src/main/zapHomeFiles/hud/target/injectionHtml.html
+++ b/src/main/zapHomeFiles/hud/target/injectionHtml.html
@@ -1,1 +1,1 @@
-<script src="<<FILE_PREFIX>>?zapfile=inject.js"></script>
+<script src="<<FILE_PREFIX>>/inject.js"></script>

--- a/src/main/zapHomeFiles/hud/utils.js
+++ b/src/main/zapHomeFiles/hud/utils.js
@@ -24,7 +24,7 @@ var utils = (function() {
 	var ZAP_HUD_FILES = '<<ZAP_HUD_FILES>>';
 	var IS_DEV_MODE = '<<DEV_MODE>>' === 'true' ? true : false ;
 
-	var BUTTON_HTML = '<div class="button" id="BUTTON_NAME-button">\n<div class="button-icon" id="BUTTON_NAME-button-icon"><img src="' + ZAP_HUD_FILES + '?image=IMAGE_NAME" alt="IMAGE_NAME" height="16" width="16"></div>\n<div class="button-data" id="BUTTON_NAME-button-data">BUTTON_DATA</div>\n<div class="button-label" id="BUTTON_NAME-button-label">BUTTON_LABEL</div>\n</div>\n';
+	var BUTTON_HTML = '<div class="button" id="BUTTON_NAME-button">\n<div class="button-icon" id="BUTTON_NAME-button-icon"><img src="' + ZAP_HUD_FILES + '/image/IMAGE_NAME" alt="IMAGE_NAME" height="16" width="16"></div>\n<div class="button-data" id="BUTTON_NAME-button-data">BUTTON_DATA</div>\n<div class="button-label" id="BUTTON_NAME-button-label">BUTTON_LABEL</div>\n</div>\n';
 	var BUTTON_NAME = /BUTTON_NAME/g;
 	var BUTTON_DATA_DIV  = /<div class="button-data" id="BUTTON_NAME-button-data">BUTTON_DATA<\/div>/g;
 	var BUTTON_DATA = /BUTTON_DATA/g;
@@ -692,11 +692,11 @@ var utils = (function() {
 	
 	
 	function getZapFilePath(file) {
-		return ZAP_HUD_FILES + '?name=' + file;
+		return ZAP_HUD_FILES + '/file/' + file;
 	}
 	
 	function getZapImagePath(file) {
-		return ZAP_HUD_FILES + '?image=' + file;
+		return ZAP_HUD_FILES + '/image/' + file;
 	}
 	
 	function log(level, method, message, object) {


### PR DESCRIPTION
I've not updated the changelog as this is an 'internal' change to support #459
URLs used by the HUD to request files and images will now have formats like:

- `https://zap//zapCallBackUrl/<random number>/file/panel.html`
- `https://zap//zapCallBackUrl/<random number>/image/target-grey.png`

Signed-off-by: Simon Bennetts <psiinon@gmail.com>