### PR TITLE
Correct Content-Length of upgraded responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - Hide drawer at the same time as the side panels [#552](https://github.com/zaproxy/zap-hud/issues/552)
 
+### Fixed
+ - Correct Content-Length of upgraded responses.
+
 ## [0.5.0] - 2019-07-24
 
 ### Added

--- a/src/main/java/org/zaproxy/zap/extension/hud/HttpUpgradeProxyListener.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HttpUpgradeProxyListener.java
@@ -128,7 +128,7 @@ public class HttpUpgradeProxyListener implements OverrideMessageProxyListener {
                         // Need to replace hardcoded http URLs with https ones
                         msg.getResponseBody()
                                 .setBody(respBody.replace("http://" + domain, "https://" + domain));
-                        msg.getResponseHeader().setContentLength(msg.getRequestBody().length());
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
                     }
                     if (respBody.contains("ws://")) {
                         // Need to replace hardcoded ws URLs with wss ones
@@ -139,7 +139,7 @@ public class HttpUpgradeProxyListener implements OverrideMessageProxyListener {
                             extHud.addUpgradedHttpsDomain(uri);
                         }
                         msg.getResponseBody().setBody(body);
-                        msg.getResponseHeader().setContentLength(msg.getRequestBody().length());
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
                     }
                 }
             } catch (URIException e) {

--- a/src/test/java/org/zaproxy/zap/extension/hud/HttpUpgradeProxyListenerTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/HttpUpgradeProxyListenerTest.java
@@ -45,16 +45,14 @@ public class HttpUpgradeProxyListenerTest {
         Mockito.when(ext.isUpgradedHttpsDomain(httpUri)).thenReturn(true);
 
         HttpUpgradeProxyListener hupl = new HttpUpgradeProxyListener(ext);
-        HttpMessage msg = new HttpMessage();
-        msg.getRequestHeader().setURI(httpUri);
-        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html");
-        msg.setResponseBody(body);
+        HttpMessage msg = createMessage(httpUri, "text/html", body);
 
         // When
         hupl.onHttpResponseReceived(msg);
 
         // Then
         assertEquals(body.replace(httpUrl, httpsUrl), msg.getResponseBody().toString());
+        assertEquals(msg.getResponseBody().length(), msg.getResponseHeader().getContentLength());
     }
 
     @Test
@@ -74,16 +72,14 @@ public class HttpUpgradeProxyListenerTest {
         Mockito.when(ext.isUpgradedHttpsDomain(httpUri)).thenReturn(true);
 
         HttpUpgradeProxyListener hupl = new HttpUpgradeProxyListener(ext);
-        HttpMessage msg = new HttpMessage();
-        msg.getRequestHeader().setURI(httpUri);
-        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html");
-        msg.setResponseBody(body);
+        HttpMessage msg = createMessage(httpUri, "text/html", body);
 
         // When
         hupl.onHttpResponseReceived(msg);
 
         // Then
         assertEquals(body.replace(httpUrl, httpsUrl), msg.getResponseBody().toString());
+        assertEquals(msg.getResponseBody().length(), msg.getResponseHeader().getContentLength());
     }
 
     @Test
@@ -96,16 +92,14 @@ public class HttpUpgradeProxyListenerTest {
         Mockito.when(ext.isUpgradedHttpsDomain(httpUri)).thenReturn(true);
 
         HttpUpgradeProxyListener hupl = new HttpUpgradeProxyListener(ext);
-        HttpMessage msg = new HttpMessage();
-        msg.getRequestHeader().setURI(httpUri);
-        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "image/png");
-        msg.setResponseBody(body);
+        HttpMessage msg = createMessage(httpUri, "image/png", body);
 
         // When
         hupl.onHttpResponseReceived(msg);
 
         // Then
         assertEquals(body, msg.getResponseBody().toString());
+        assertEquals(msg.getResponseBody().length(), msg.getResponseHeader().getContentLength());
     }
 
     @Test
@@ -118,16 +112,14 @@ public class HttpUpgradeProxyListenerTest {
         Mockito.when(ext.isUpgradedHttpsDomain(httpUri)).thenReturn(false);
 
         HttpUpgradeProxyListener hupl = new HttpUpgradeProxyListener(ext);
-        HttpMessage msg = new HttpMessage();
-        msg.getRequestHeader().setURI(httpUri);
-        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html");
-        msg.setResponseBody(body);
+        HttpMessage msg = createMessage(httpUri, "text/html", body);
 
         // When
         hupl.onHttpResponseReceived(msg);
 
         // Then
         assertEquals(body, msg.getResponseBody().toString());
+        assertEquals(msg.getResponseBody().length(), msg.getResponseHeader().getContentLength());
     }
 
     @Test
@@ -162,5 +154,15 @@ public class HttpUpgradeProxyListenerTest {
         assertEquals(2, list.size());
         assertTrue(list.contains(wssUri1));
         assertTrue(list.contains(wssUri2));
+    }
+
+    private static HttpMessage createMessage(URI uri, String contentType, String body)
+            throws URIException {
+        HttpMessage msg = new HttpMessage();
+        msg.getRequestHeader().setURI(uri);
+        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, contentType);
+        msg.setResponseBody(body);
+        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+        return msg;
     }
 }


### PR DESCRIPTION
Use the length of the response body instead of request.

---
Fixes the issue reported in OWASP Slack channel when accessing Juice Shop.