### PR TITLE
Relocate browser tests

### DIFF
--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/BrowsersTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/BrowsersTest.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.hud.ui.firefox;
+package org.zaproxy.zap.extension.hud.ui.browser;
 
 import io.github.bonigarcia.Options;
 import io.github.bonigarcia.SeleniumExtension;
@@ -28,10 +28,10 @@ import org.openqa.selenium.remote.CapabilityType;
 import org.zaproxy.zap.extension.hud.ui.Constants;
 
 @ExtendWith({SeleniumExtension.class})
-public abstract class FirefoxUnitTest {
+public abstract class BrowsersTest {
     @Options FirefoxOptions firefoxOptions;
 
-    public FirefoxUnitTest() {
+    public BrowsersTest() {
         this.firefoxOptions = new FirefoxOptions();
 
         Proxy proxy = new Proxy();

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/TopSitesUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/TopSitesUnitTest.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.hud.ui.firefox;
+package org.zaproxy.zap.extension.hud.ui.browser;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 @Tag("remote")
 /** Alexa top sites */
-public class TopSitesUnitTest extends FirefoxUnitTest {
+public class TopSitesUnitTest extends BrowsersTest {
 
     private void testSite(FirefoxDriver driver, String site) throws InterruptedException {
         HUD hud = new HUD(driver);

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/TrickySitesUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/TrickySitesUnitTest.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.hud.ui.firefox;
+package org.zaproxy.zap.extension.hud.ui.browser;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 @Tag("remote")
 /** Sites that have been known to cause the HUD problems. Expect this to be added to! */
-public class TrickySitesUnitTest extends FirefoxUnitTest {
+public class TrickySitesUnitTest extends BrowsersTest {
 
     private void testSite(FirefoxDriver driver, String site) throws InterruptedException {
         HUD hud = new HUD(driver);

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/badsite/BadSiteUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/badsite/BadSiteUnitTest.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.hud.ui.firefox.badsite;
+package org.zaproxy.zap.extension.hud.ui.browser.badsite;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -43,12 +43,12 @@ import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.zaproxy.zap.extension.hud.HudAPI;
 import org.zaproxy.zap.extension.hud.tutorial.pages.IntroPage;
-import org.zaproxy.zap.extension.hud.ui.firefox.FirefoxUnitTest;
-import org.zaproxy.zap.extension.hud.ui.firefox.tutorial.TutorialStatics;
+import org.zaproxy.zap.extension.hud.ui.browser.BrowsersTest;
+import org.zaproxy.zap.extension.hud.ui.browser.tutorial.TutorialStatics;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 @Tag("tutorial")
-public class BadSiteUnitTest extends FirefoxUnitTest {
+public class BadSiteUnitTest extends BrowsersTest {
 
     private static final String SERVICE_WORKER = "serviceworker.js";
     private static final String BAD_SITE_TEST_KEY = "badsitetest";

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/AlertNotificationsPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/AlertNotificationsPageUnitTest.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.hud.ui.firefox.tutorial;
+package org.zaproxy.zap.extension.hud.ui.browser.tutorial;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,12 +33,12 @@ import org.openqa.selenium.firefox.FirefoxDriver;
 import org.zaproxy.zap.extension.hud.tutorial.pages.AlertNotificationsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.AlertsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.PageAlertsPage;
-import org.zaproxy.zap.extension.hud.ui.firefox.FirefoxUnitTest;
+import org.zaproxy.zap.extension.hud.ui.browser.BrowsersTest;
 import org.zaproxy.zap.extension.hud.ui.generic.GenericUnitTest;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 @Tag("tutorial")
-public class AlertNotificationsPageUnitTest extends FirefoxUnitTest {
+public class AlertNotificationsPageUnitTest extends BrowsersTest {
 
     @Test
     public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/AlertsPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/AlertsPageUnitTest.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.hud.ui.firefox.tutorial;
+package org.zaproxy.zap.extension.hud.ui.browser.tutorial;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -26,41 +26,43 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.zaproxy.zap.extension.hud.tutorial.pages.IntroPage;
-import org.zaproxy.zap.extension.hud.tutorial.pages.UpgradePage;
-import org.zaproxy.zap.extension.hud.tutorial.pages.WarningPage;
-import org.zaproxy.zap.extension.hud.ui.firefox.FirefoxUnitTest;
+import org.zaproxy.zap.extension.hud.tutorial.pages.AlertNotificationsPage;
+import org.zaproxy.zap.extension.hud.tutorial.pages.AlertsPage;
+import org.zaproxy.zap.extension.hud.tutorial.pages.FramesPage;
+import org.zaproxy.zap.extension.hud.ui.browser.BrowsersTest;
 import org.zaproxy.zap.extension.hud.ui.generic.GenericUnitTest;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 @Tag("tutorial")
-public class WarningPageUnitTest extends FirefoxUnitTest {
+public class AlertsPageUnitTest extends BrowsersTest {
 
     @Test
     public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {
         HUD hud = new HUD(driver);
-        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(WarningPage.NAME));
+        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertsPage.NAME));
         GenericUnitTest.runAllTests(driver);
     }
 
     @Test
     public void testPreviousButtonWorks(FirefoxDriver driver) {
         HUD hud = new HUD(driver);
-        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(WarningPage.NAME));
+        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertsPage.NAME));
         WebElement previousButton = TutorialStatics.getPreviousButton(driver);
         assertNotNull(previousButton);
         previousButton.click();
-        assertEquals(TutorialStatics.getTutorialHudUrl(IntroPage.NAME), driver.getCurrentUrl());
+        assertEquals(TutorialStatics.getTutorialHudUrl(FramesPage.NAME), driver.getCurrentUrl());
     }
 
     @Test
     public void testNextPageButtonWorks(FirefoxDriver driver) {
         HUD hud = new HUD(driver);
-        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(WarningPage.NAME));
+        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertsPage.NAME));
         WebElement nextButton = TutorialStatics.getNextButton(driver);
         assertNotNull(nextButton);
         nextButton.click();
         hud.waitForPageLoad();
-        assertEquals(TutorialStatics.getTutorialHudUrl(UpgradePage.NAME), driver.getCurrentUrl());
+        assertEquals(
+                TutorialStatics.getTutorialHudUrl(AlertNotificationsPage.NAME),
+                driver.getCurrentUrl());
     }
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/FramesPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/FramesPageUnitTest.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.hud.ui.firefox.tutorial;
+package org.zaproxy.zap.extension.hud.ui.browser.tutorial;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -39,12 +39,12 @@ import org.zaproxy.zap.extension.hud.tutorial.pages.AlertsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.FramesPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.UpgradePage;
 import org.zaproxy.zap.extension.hud.ui.Constants;
-import org.zaproxy.zap.extension.hud.ui.firefox.FirefoxUnitTest;
+import org.zaproxy.zap.extension.hud.ui.browser.BrowsersTest;
 import org.zaproxy.zap.extension.hud.ui.generic.GenericUnitTest;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 @Tag("tutorial")
-public class FramesPageUnitTest extends FirefoxUnitTest {
+public class FramesPageUnitTest extends BrowsersTest {
 
     @Test
     public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/PageAlertsPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/PageAlertsPageUnitTest.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.hud.ui.firefox.tutorial;
+package org.zaproxy.zap.extension.hud.ui.browser.tutorial;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -34,12 +34,12 @@ import org.zaproxy.zap.extension.hud.tutorial.pages.AlertNotificationsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.PageAlertsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.SiteAlertsPage;
 import org.zaproxy.zap.extension.hud.ui.Constants;
-import org.zaproxy.zap.extension.hud.ui.firefox.FirefoxUnitTest;
+import org.zaproxy.zap.extension.hud.ui.browser.BrowsersTest;
 import org.zaproxy.zap.extension.hud.ui.generic.GenericUnitTest;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 @Tag("tutorial")
-public class PageAlertsPageUnitTest extends FirefoxUnitTest {
+public class PageAlertsPageUnitTest extends BrowsersTest {
 
     @Test
     public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/TutorialStatics.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/TutorialStatics.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.hud.ui.firefox.tutorial;
+package org.zaproxy.zap.extension.hud.ui.browser.tutorial;
 
 import org.junit.jupiter.api.Tag;
 import org.openqa.selenium.By;

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/WarningPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/WarningPageUnitTest.java
@@ -17,59 +17,50 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.hud.ui.firefox.tutorial;
+package org.zaproxy.zap.extension.hud.ui.browser.tutorial;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.zaproxy.zap.extension.hud.tutorial.pages.IntroPage;
+import org.zaproxy.zap.extension.hud.tutorial.pages.UpgradePage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.WarningPage;
-import org.zaproxy.zap.extension.hud.ui.firefox.FirefoxUnitTest;
+import org.zaproxy.zap.extension.hud.ui.browser.BrowsersTest;
 import org.zaproxy.zap.extension.hud.ui.generic.GenericUnitTest;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 @Tag("tutorial")
-public class WelcomePageUnitTest extends FirefoxUnitTest {
+public class WarningPageUnitTest extends BrowsersTest {
 
     @Test
     public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {
         HUD hud = new HUD(driver);
-        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
+        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(WarningPage.NAME));
         GenericUnitTest.runAllTests(driver);
     }
 
     @Test
-    public void testRedirectToHttps(FirefoxDriver driver) {
+    public void testPreviousButtonWorks(FirefoxDriver driver) {
         HUD hud = new HUD(driver);
-        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
+        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(WarningPage.NAME));
+        WebElement previousButton = TutorialStatics.getPreviousButton(driver);
+        assertNotNull(previousButton);
+        previousButton.click();
         assertEquals(TutorialStatics.getTutorialHudUrl(IntroPage.NAME), driver.getCurrentUrl());
-    }
-
-    @Test
-    public void testNoPreviousButton(FirefoxDriver driver) {
-        HUD hud = new HUD(driver);
-        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
-        assertThrows(
-                NoSuchElementException.class,
-                () -> {
-                    TutorialStatics.getPreviousButton(driver);
-                });
     }
 
     @Test
     public void testNextPageButtonWorks(FirefoxDriver driver) {
         HUD hud = new HUD(driver);
-        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
+        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(WarningPage.NAME));
         WebElement nextButton = TutorialStatics.getNextButton(driver);
         assertNotNull(nextButton);
         nextButton.click();
         hud.waitForPageLoad();
-        assertEquals(TutorialStatics.getTutorialHudUrl(WarningPage.NAME), driver.getCurrentUrl());
+        assertEquals(TutorialStatics.getTutorialHudUrl(UpgradePage.NAME), driver.getCurrentUrl());
     }
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/WelcomePageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/WelcomePageUnitTest.java
@@ -17,52 +17,59 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.hud.ui.firefox.tutorial;
+package org.zaproxy.zap.extension.hud.ui.browser.tutorial;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.zaproxy.zap.extension.hud.tutorial.pages.AlertNotificationsPage;
-import org.zaproxy.zap.extension.hud.tutorial.pages.AlertsPage;
-import org.zaproxy.zap.extension.hud.tutorial.pages.FramesPage;
-import org.zaproxy.zap.extension.hud.ui.firefox.FirefoxUnitTest;
+import org.zaproxy.zap.extension.hud.tutorial.pages.IntroPage;
+import org.zaproxy.zap.extension.hud.tutorial.pages.WarningPage;
+import org.zaproxy.zap.extension.hud.ui.browser.BrowsersTest;
 import org.zaproxy.zap.extension.hud.ui.generic.GenericUnitTest;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 @Tag("tutorial")
-public class AlertsPageUnitTest extends FirefoxUnitTest {
+public class WelcomePageUnitTest extends BrowsersTest {
 
     @Test
     public void genericPageUnitTests(FirefoxDriver driver) throws InterruptedException {
         HUD hud = new HUD(driver);
-        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertsPage.NAME));
+        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
         GenericUnitTest.runAllTests(driver);
     }
 
     @Test
-    public void testPreviousButtonWorks(FirefoxDriver driver) {
+    public void testRedirectToHttps(FirefoxDriver driver) {
         HUD hud = new HUD(driver);
-        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertsPage.NAME));
-        WebElement previousButton = TutorialStatics.getPreviousButton(driver);
-        assertNotNull(previousButton);
-        previousButton.click();
-        assertEquals(TutorialStatics.getTutorialHudUrl(FramesPage.NAME), driver.getCurrentUrl());
+        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
+        assertEquals(TutorialStatics.getTutorialHudUrl(IntroPage.NAME), driver.getCurrentUrl());
+    }
+
+    @Test
+    public void testNoPreviousButton(FirefoxDriver driver) {
+        HUD hud = new HUD(driver);
+        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
+        assertThrows(
+                NoSuchElementException.class,
+                () -> {
+                    TutorialStatics.getPreviousButton(driver);
+                });
     }
 
     @Test
     public void testNextPageButtonWorks(FirefoxDriver driver) {
         HUD hud = new HUD(driver);
-        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(AlertsPage.NAME));
+        hud.openUrlWaitForHud(TutorialStatics.getTutorialUrl(IntroPage.NAME));
         WebElement nextButton = TutorialStatics.getNextButton(driver);
         assertNotNull(nextButton);
         nextButton.click();
         hud.waitForPageLoad();
-        assertEquals(
-                TutorialStatics.getTutorialHudUrl(AlertNotificationsPage.NAME),
-                driver.getCurrentUrl());
+        assertEquals(TutorialStatics.getTutorialHudUrl(WarningPage.NAME), driver.getCurrentUrl());
     }
 }


### PR DESCRIPTION
Move the tests to generic package (`browser` instead of `firefox`).
Rename the base class to `BrowsersTest` (from `FirefoxUnitTest`).

Part of #345 - Run functional tests with Chrome