### PR TITLE
Dialogues closed by pressing the escape key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Added 'Toggle Script' tool, allowing user-made scripts to be toggled on and off from the HUD [#335](https://github.com/zaproxy/zap-hud/issues/335)
 
+### Fixed
+ - Dialogue windows close properly when the Escape key is pressed [#71](https://github.com/zaproxy/zap-hud/issues/71)
+
 ## [0.7.0] - 2019-10-07
 
 ### Changed

--- a/src/main/zapHomeFiles/hud/display.js
+++ b/src/main/zapHomeFiles/hud/display.js
@@ -33,7 +33,18 @@ Vue.component('modal', {
 			}
 
 			app.keepShowing = false;
+		},
+		escapeKey(event) {
+			if (this.show && (event.key === 'Escape' || event.key === 'Esc')) {
+				this.close();
+			}
 		}
+	},
+	mounted() {
+		document.addEventListener('keydown', this.escapeKey);
+	},
+	beforeDestroy() {
+		document.removeEventListener('keydown', this.escapeKey);
 	}
 });
 


### PR DESCRIPTION
Fixes #71 

Dialogues can now be closed by pressing the escape key. However, one thing to note is that the dialogue must be brought into focus by clicking on it first. If you would like me to work on having the dialogue autofocus just let me know.

Please let me know if you need any changes. Thanks!!