### PR TITLE
introduce eslint for DOM XSS linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,25 @@
       "src/test/js/**",
       "src/webpack/**"
     ],
+    "plugins": ["no-unsanitized"],
     "rules": {
       "no-negated-condition": "warn",
+      "no-unsanitized/method": ["error",
+        {
+          "escape": {
+            "methods": [
+              "DOMPurify.sanitize"
+            ]
+          }
+        }],
+      "no-unsanitized/property": ["error",
+        {
+          "escape": {
+            "methods": [
+              "DOMPurify.sanitize"
+            ]
+          }
+        }],
       "no-unused-vars": "warn",
       "prefer-destructuring": "warn",
       "unicorn/no-for-loop": "warn",
@@ -80,6 +97,7 @@
   "devDependencies": {
     "ava": "^2.4.0",
     "css-loader": "^3.2.0",
+    "eslint-plugin-no-unsanitized": "^3.0.2",
     "lint-staged": "^9.4.2",
     "vue-loader": "^15.7.1",
     "vue-style-loader": "^4.1.2",

--- a/src/main/zapHomeFiles/hud/display.js
+++ b/src/main/zapHomeFiles/hud/display.js
@@ -1113,6 +1113,8 @@ navigator.serviceWorker.addEventListener('message', event => {
 
 			channel.port1.addEventListener('message', event => {
 				// Open window and inject the HTML report
+				// FIXME: remove after #620
+				// eslint-disable-next-line no-unsanitized/property
 				window.open('').document.body.innerHTML = event.data.response;
 			});
 


### PR DESCRIPTION
For this to be immediately useful, one needs to:
- [ ] fix existing violations (below) #621
- [x] ~in package.json, add "script" to run eslint on all relevant source files~
- [x] integrate script into CI


Existing violations:
```
zap-hud/src/main/zapHomeFiles/hud/display.js
  1116:5  error  Unsafe assignment to innerHTML  no-unsanitized/property
zap-hud/src/main/zapHomeFiles/hud/libraries/alertify.js
  1:2257  error  Unsafe assignment to innerHTML  no-unsanitized/property
  1:2897  error  Unsafe assignment to innerHTML  no-unsanitized/property
zap-hud/src/main/zapHomeFiles/hud/target/inject.js
  454:3  error  Unsafe assignment to innerHTML  no-unsanitized/property
```