### PR TITLE
Remove URL from main extension

### DIFF
--- a/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.hud;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -338,15 +336,6 @@ public class ExtensionHUD extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override


### PR DESCRIPTION
It pointed to zap-extensions repo which does not seem to be relevant or
helpful.

---
Does it worth changing to this repo or the help page instead?