### PR TITLE
Add tweet link to the completion screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
  - Added 'Toggle Script' tool, allowing user-made scripts to be toggled on and off from the HUD [#335](https://github.com/zaproxy/zap-hud/issues/335)
+ - Tweet link on completing the tutorial
 
 ### Fixed
  - Dialogue windows close properly when the Escape key is pressed [#71](https://github.com/zaproxy/zap-hud/issues/71)

--- a/src/main/zapHomeFiles/hudtutorial/en_GB/Complete.html
+++ b/src/main/zapHomeFiles/hudtutorial/en_GB/Complete.html
@@ -7,7 +7,9 @@
 <body>
 <div class="roundContainer">
 	<h1>Tutorial Completed</H1>
-	Congratulations, you have completed this HUD tutorial!
+	Congratulations, you have completed the HUD tutorial!
+	<p>
+	If you found it useful please <a href="https://ctt.ac/z075x">tweet</a> about it.
 	<p>
 	If you have any questions about the HUD or feedback to help us make it better then please post
 	your comments to the <a href="https://groups.google.com/group/zaproxy-hud">ZAP HUD Group</a>. 


### PR DESCRIPTION
Uses a free account with https://clicktotweet.com/ associated with the @zaproxy twitter account.
Users wont be logged into twitter as its a new profile, so they will see a screen like this:

![Screenshot_2019-11-06 Post a Tweet on Twitter](https://user-images.githubusercontent.com/1081115/68299827-60f43b80-0094-11ea-803a-3b691206425a.png)


Signed-off-by: Simon Bennetts <psiinon@gmail.com>