### PR TITLE
Handle sites that fail when 'only in scope' switched on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  - Dialogue windows close properly when the Escape key is pressed [#71](https://github.com/zaproxy/zap-hud/issues/71)
+ - Sites upgraded to https fail if 'only in scope' switched on [#316](https://github.com/zaproxy/zap-hud/issues/316)
 
 ## [0.7.0] - 2019-10-07
 


### PR DESCRIPTION
Fixes #316

To test:

1. Launch browser with HUD
1. View site, HUD should be on
1. In ZAP set HUD option to only enable it if in scope
1. Follow an app link in the browser

Previously this would have failed, it should now work.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>