### PR TITLE
Bugfix/Alert i18n bug #235

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Alerts open with correct active tab in other supported languages besides English (ie French). [#235](https://github.com/zaproxy/zap-hud/issues/235)
 
 ## [0.8.0] - 2019-11-25
 

--- a/src/main/zapHomeFiles/hud/tools/pageAlertsHigh.js
+++ b/src/main/zapHomeFiles/hud/tools/pageAlertsHigh.js
@@ -16,6 +16,7 @@ const PageAlertsHigh = (function () {
 	ICONS.PA = 'page-alerts-high.png';
 	const ALERT_TYPE = 'page-alerts';
 	const ALERT_RISK = 'High';
+	const ALERT_RISK_LABEL = I18n.t('alerts_risk_high');
 
 	// Todo: change this to a util function that reads in a config file (json/xml)
 	function initializeStorage() {
@@ -36,7 +37,7 @@ const PageAlertsHigh = (function () {
 	}
 
 	function showAlerts(tabId, url) {
-		alertUtils.showPageAlerts(tabId, DIALOG, url, ALERT_RISK);
+		alertUtils.showPageAlerts(tabId, DIALOG, url, ALERT_RISK_LABEL);
 	}
 
 	function showOptions(tabId) {

--- a/src/main/zapHomeFiles/hud/tools/pageAlertsInformational.js
+++ b/src/main/zapHomeFiles/hud/tools/pageAlertsInformational.js
@@ -16,6 +16,7 @@ const PageAlertsInformational = (function () {
 	ICONS.PA = 'page-alerts-informational.png';
 	const ALERT_TYPE = 'page-alerts';
 	const ALERT_RISK = 'Informational';
+	const ALERT_RISK_LABEL = I18n.t('alerts_risk_info');
 
 	// Todo: change this to a util function that reads in a config file (json/xml)
 	function initializeStorage() {
@@ -36,7 +37,7 @@ const PageAlertsInformational = (function () {
 	}
 
 	function showAlerts(tabId, url) {
-		alertUtils.showPageAlerts(tabId, DIALOG, url, ALERT_RISK);
+		alertUtils.showPageAlerts(tabId, DIALOG, url, ALERT_RISK_LABEL);
 	}
 
 	function showOptions(tabId) {

--- a/src/main/zapHomeFiles/hud/tools/pageAlertsLow.js
+++ b/src/main/zapHomeFiles/hud/tools/pageAlertsLow.js
@@ -16,7 +16,7 @@ const PageAlertsLow = (function () {
 	ICONS.PA = 'page-alerts-low.png';
 	const ALERT_TYPE = 'page-alerts';
 	const ALERT_RISK = 'Low';
-
+	const ALERT_RISK_LABEL = I18n.t('alerts_risk_low');
 	// Todo: change this to a util function that reads in a config file (json/xml)
 	function initializeStorage() {
 		const tool = {};
@@ -36,7 +36,7 @@ const PageAlertsLow = (function () {
 	}
 
 	function showAlerts(tabId, url) {
-		alertUtils.showPageAlerts(tabId, DIALOG, url, ALERT_RISK);
+		alertUtils.showPageAlerts(tabId, DIALOG, url, ALERT_RISK_LABEL);
 	}
 
 	function showOptions(tabId) {

--- a/src/main/zapHomeFiles/hud/tools/pageAlertsMedium.js
+++ b/src/main/zapHomeFiles/hud/tools/pageAlertsMedium.js
@@ -16,6 +16,7 @@ const PageAlertsMedium = (function () {
 	ICONS.PA = 'page-alerts-medium.png';
 	const ALERT_TYPE = 'page-alerts';
 	const ALERT_RISK = 'Medium';
+	const ALERT_RISK_LABEL = I18n.t('alerts_risk_medium');
 
 	// Todo: change this to a util function that reads in a config file (json/xml)
 	function initializeStorage() {
@@ -36,7 +37,7 @@ const PageAlertsMedium = (function () {
 	}
 
 	function showAlerts(tabId, url) {
-		alertUtils.showPageAlerts(tabId, DIALOG, url, ALERT_RISK);
+		alertUtils.showPageAlerts(tabId, DIALOG, url, ALERT_RISK_LABEL);
 	}
 
 	function showOptions(tabId) {

--- a/src/main/zapHomeFiles/hud/tools/siteAlertsHigh.js
+++ b/src/main/zapHomeFiles/hud/tools/siteAlertsHigh.js
@@ -16,6 +16,7 @@ const SiteAlertsHigh = (function () {
 	ICONS.PA = 'site-alerts-high.png';
 	const ALERT_TYPE = 'site-alerts';
 	const ALERT_RISK = 'High';
+	const ALERT_RISK_LABEL = I18n.t('alerts_risk_high');
 
 	// Todo: change this to a util function that reads in a config file (json/xml)
 	function initializeStorage() {
@@ -36,7 +37,7 @@ const SiteAlertsHigh = (function () {
 	}
 
 	function showAlerts(tabId, domain) {
-		alertUtils.showSiteAlerts(tabId, DIALOG, domain, ALERT_RISK);
+		alertUtils.showSiteAlerts(tabId, DIALOG, domain, ALERT_RISK_LABEL);
 	}
 
 	function showOptions(tabId) {

--- a/src/main/zapHomeFiles/hud/tools/siteAlertsInformational.js
+++ b/src/main/zapHomeFiles/hud/tools/siteAlertsInformational.js
@@ -16,6 +16,7 @@ const SiteAlertsInformational = (function () {
 	ICONS.PA = 'site-alerts-informational.png';
 	const ALERT_TYPE = 'site-alerts';
 	const ALERT_RISK = 'Informational';
+	const ALERT_RISK_LABEL = I18n.t('alerts_risk_info');
 
 	// Todo: change this to a util function that reads in a config file (json/xml)
 	function initializeStorage() {
@@ -36,7 +37,7 @@ const SiteAlertsInformational = (function () {
 	}
 
 	function showAlerts(tabId, domain) {
-		alertUtils.showSiteAlerts(tabId, DIALOG, domain, ALERT_RISK);
+		alertUtils.showSiteAlerts(tabId, DIALOG, domain, ALERT_RISK_LABEL);
 	}
 
 	function showOptions(tabId) {

--- a/src/main/zapHomeFiles/hud/tools/siteAlertsLow.js
+++ b/src/main/zapHomeFiles/hud/tools/siteAlertsLow.js
@@ -16,6 +16,7 @@ const SiteAlertsLow = (function () {
 	ICONS.PA = 'site-alerts-low.png';
 	const ALERT_TYPE = 'site-alerts';
 	const ALERT_RISK = 'Low';
+	const ALERT_RISK_LABEL = I18n.t('alerts_risk_low');
 
 	// Todo: change this to a util function that reads in a config file (json/xml)
 	function initializeStorage() {
@@ -36,7 +37,7 @@ const SiteAlertsLow = (function () {
 	}
 
 	function showAlerts(tabId, domain) {
-		alertUtils.showSiteAlerts(tabId, DIALOG, domain, ALERT_RISK);
+		alertUtils.showSiteAlerts(tabId, DIALOG, domain, ALERT_RISK_LABEL);
 	}
 
 	function showOptions(tabId) {

--- a/src/main/zapHomeFiles/hud/tools/siteAlertsMedium.js
+++ b/src/main/zapHomeFiles/hud/tools/siteAlertsMedium.js
@@ -16,6 +16,7 @@ const SiteAlertsMedium = (function () {
 	ICONS.PA = 'site-alerts-medium.png';
 	const ALERT_TYPE = 'site-alerts';
 	const ALERT_RISK = 'Medium';
+	const ALERT_RISK_LABEL = I18n.t('alerts_risk_medium');
 
 	// Todo: change this to a util function that reads in a config file (json/xml)
 	function initializeStorage() {
@@ -36,7 +37,7 @@ const SiteAlertsMedium = (function () {
 	}
 
 	function showAlerts(tabId, domain) {
-		alertUtils.showSiteAlerts(tabId, DIALOG, domain, ALERT_RISK);
+		alertUtils.showSiteAlerts(tabId, DIALOG, domain, ALERT_RISK_LABEL);
 	}
 
 	function showOptions(tabId) {


### PR DESCRIPTION
Worked with David on this today. Figured out it was pretty much what Simon was saying in the issue description. The Alert_Risk wasn't getting set to the translated word, but we couldn't change it everywhere because it was also being used to make api calls. So we opted to create another constant with the correct translated function call and implement that only in the showAlerts function. 

Fix #235.

I tried running the tests with npm run test but it was getting an error on 
```
ERROR in ./src/main/zapHomeFiles/hud/serviceworker.js 4:3
Module parse failed: Unexpected token (4:3)
File was processed with these loaders:
 * ./src/webpack/loaders/zap-loader.js
You may need an additional loader to handle the result of these loaders.
| const ZAP_HUD_FILES = 'https://zap';
| const toolScripts = [
> 	''http://zap/to/some/tool'' <<<these are two single quotes not double quotes>>>
| ];
```
I went to zap-loader.js and found that there are escaped single quotes and it said they are there to make the js linter happy but when i removed them the test completed :) I didnt push that change here but just wanted to mention it. 
`source = source.replace('<<ZAP_HUD_TOOLS>>', '\'http://zap/to/some/tool\'');`