### PR TITLE
Update add-on plugin to add links, tweak HelpSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add info and repo URLs to the add-on manifest.
+
 ### Fixed
 - Alerts open with correct active tab in other supported languages besides English (ie French). [#235](https://github.com/zaproxy/zap-hud/issues/235)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ import org.zaproxy.gradle.tasks.ZapShutdown
 plugins {
     `java-library`
     jacoco
-    id("org.zaproxy.add-on") version "0.2.0"
+    id("org.zaproxy.add-on") version "0.3.0"
     id("com.diffplug.gradle.spotless") version "3.15.0"
     id("org.ysb33r.nodejs.npm") version "0.6.2"
 }
@@ -55,6 +55,8 @@ zapAddOn {
 
     manifest {
         author.set("ZAP Dev Team")
+        url.set("https://www.zaproxy.org/docs/desktop/addons/hud/")
+        repo.set("https://github.com/zaproxy/zap-hud/")
         changesFile.set(tasks.named<ConvertMarkdownToHtml>("generateManifestChanges").flatMap { it.html })
         files.from(generatedI18nJsFileDir)
         files.from(npmDepsDir)

--- a/src/main/javahelp/org/zaproxy/zap/extension/hud/resources/help/helpset.hs
+++ b/src/main/javahelp/org/zaproxy/zap/extension/hud/resources/help/helpset.hs
@@ -3,10 +3,10 @@
   PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp HelpSet Version 2.0//EN"
          "http://java.sun.com/products/javahelp/helpset_2_0.dtd">
 <helpset version="2.0" xml:lang="en-GB">
-  <title>HUD | ZAP Extension</title>
+  <title>HUD Add-on</title>
 
   <maps>
-     <homeID>top</homeID>
+     <homeID>addon.hud</homeID>
      <mapref location="map.jhm"/>
   </maps>
 


### PR DESCRIPTION
Update add-on plugin to 0.3.0 and add the repo/info URLs to the
manifest.
Change HelpSet to link to the main help page and change the title to use
"add-on" instead of "extension".