### PR TITLE
Change cursor to pointer on clickable elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Changed HUD toolbar icon to add a target overlay when 'only in scope' option enabled.
+- Change cursor to pointer on clickable elements
 
 ## [0.9.0] - 2020-01-15
 ### Added

--- a/src/main/zapHomeFiles/hud/display.css
+++ b/src/main/zapHomeFiles/hud/display.css
@@ -8,10 +8,22 @@ body {
   text-indent: -1em;
 }
 
+.site-tree-control {
+  cursor: pointer;
+}
+
 span.errorMessages {
   color: red;
 }
 
 .hidden {
   display: none
+}
+
+.accordion-header {
+  cursor: pointer;
+}
+
+.menu-item {
+  cursor: pointer;
 }

--- a/src/main/zapHomeFiles/hud/display.html
+++ b/src/main/zapHomeFiles/hud/display.html
@@ -407,7 +407,7 @@
         <template id="site-tree-node-template">
 			  <li>
 			    <div :class="{bold: ! model.isLeaf}">
-			      <span v-if="! model.isLeaf" @click="toggle">[{{ open ? '-' : '+' }}]</span>
+			      <span v-if="! model.isLeaf" @click="toggle" class="site-tree-control">[{{ open ? '-' : '+' }}]</span>
 			      <span v-if="model.hrefId > 0" @click="showHttpMessageDetails"><a href="#">{{ model.name }}</a></span>
 			      <span v-if="model.hrefId == 0" @click="toggle">{{ model.name }}</span>
 			    </div>

--- a/src/main/zapHomeFiles/hud/drawer.css
+++ b/src/main/zapHomeFiles/hud/drawer.css
@@ -28,6 +28,7 @@
   font-size: .7em;
   padding: 0 1%;
   margin-bottom: 1%;
+  cursor: pointer;
 }
 
 .drawer-messages .message-tr td{


### PR DESCRIPTION
Related to https://twitter.com/BumbIeBrutes/status/1208436542680772610

Prior to this change the clickable elements in the following areas did not change the cursor to a pointer:

- alert list names
- alert list links
- Site expand / contract controls
- History and websocket table lines

Signed-off-by: Simon Bennetts <psiinon@gmail.com>