### PR TITLE
Pin Firefox version in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
   - openjdk11
 
 addons:
-    firefox: latest
+    firefox: "73.0.1"
     chrome: stable
 
 before_cache:


### PR DESCRIPTION
Change Travis CI configuration to use version 73.0.1, the HUD is failing
with newer version.

Ref #701.