### PR TITLE
Do not set the background colour of help pages

### DIFF
--- a/src/main/javahelp/org/zaproxy/zap/extension/hud/resources/help/contents/hud.html
+++ b/src/main/javahelp/org/zaproxy/zap/extension/hud/resources/help/contents/hud.html
@@ -6,7 +6,7 @@
 The HUD
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>The HUD</H1>
 
 The HUD is a completely new interface that brings information and functionality from ZAP into your browser.

--- a/src/main/javahelp/org/zaproxy/zap/extension/hud/resources/help/contents/options.html
+++ b/src/main/javahelp/org/zaproxy/zap/extension/hud/resources/help/contents/options.html
@@ -4,7 +4,7 @@
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>Options HUD screen</TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 	<H1>Options HUD screen</H1>
 
 	<h2>Enable when using the ZAP Desktop</h2>


### PR DESCRIPTION
Let the UI set the colour of the background, the help pages don't
require the background to be white.

Part of zaproxy/zaproxy#5542.