### PR TITLE
Unpin Firefox version in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
   - openjdk11
 
 addons:
-    firefox: "73.0.1"
+    firefox: latest
     chrome: stable
 
 before_cache:

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/BrowsersTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/BrowsersTest.java
@@ -49,6 +49,8 @@ public abstract class BrowsersTest {
                     .addPreference("browser.safebrowsing.provider.mozilla.updateURL", "")
                     .addPreference("network.proxy.no_proxies_on", "")
                     .addPreference("network.proxy.allow_hijacking_localhost", true)
+                    // Breaks the HUD otherwise (Issue 701)
+                    .addPreference("browser.tabs.documentchannel", false)
                     .setProxy(PROXY);
 
     @Options


### PR DESCRIPTION
Change Travis CI configuration to use latest as before.
Add the preference to restore the previous behaviour which makes the HUD
work again.

Ref #701.