### PR TITLE
Make tests more reliable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -345,7 +345,7 @@ tasks.test {
 
 tasks.withType<Test>().configureEach {
     systemProperties.putAll(mapOf(
-            "wdm.chromeDriverVersion" to "78.0.3904.70",
+            "wdm.chromeDriverVersion" to "83.0.4103.39",
             "wdm.geckoDriverVersion" to "0.26.0",
             "wdm.forceCache" to "true"))
 }

--- a/gradle/travis-ci.gradle.kts
+++ b/gradle/travis-ci.gradle.kts
@@ -1,5 +1,7 @@
 // Build tweaks when running in Travis CI
 
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 fun isEnvVarTrue(envvar: String) = System.getenv(envvar) == "true"
 
 if (isEnvVarTrue("TRAVIS") && isEnvVarTrue("CI")) {
@@ -7,6 +9,7 @@ if (isEnvVarTrue("TRAVIS") && isEnvVarTrue("CI")) {
     tasks.withType(Test::class).configureEach {
         testLogging {
             exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+            events = setOf(TestLogEvent.FAILED, TestLogEvent.PASSED)
         }
     }
 

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/Constants.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/Constants.java
@@ -25,9 +25,4 @@ public class Constants {
     public static String ZAP_HOST_PORT = ZAP_HOST + ":" + ZAP_PORT;
     /** This key is set in /build.gradle.kts - these must be kept the same */
     public static String ZAP_TEST_API_KEY = "password123";
-
-    public static int POST_LOAD_DELAY_MS = 10000;
-    public static int GENERIC_TESTS_RETRY_COUNT = 30;
-    public static int GENERIC_TESTS_RETRY_SLEEP_MS = 1000;
-    public static int GENERIC_TESTS_TIMEOUT_SECS = 20;
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/BrowsersTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/BrowsersTest.java
@@ -44,6 +44,7 @@ public abstract class BrowsersTest {
     private static final FirefoxOptions FIREFOX_OPTIONS =
             new FirefoxOptions()
                     .setHeadless(true)
+                    .setAcceptInsecureCerts(true)
                     .addPreference("network.captive-portal-service.enabled", false)
                     .addPreference("browser.safebrowsing.provider.mozilla.gethashURL", "")
                     .addPreference("browser.safebrowsing.provider.mozilla.updateURL", "")
@@ -57,6 +58,7 @@ public abstract class BrowsersTest {
     private static final ChromeOptions CHROME_OPTIONS =
             new ChromeOptions()
                     .setHeadless(true)
+                    .setAcceptInsecureCerts(true)
                     .addArguments("--proxy-bypass-list=<-loopback>", "--window-size=1024,768")
                     .setProxy(PROXY);
 

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/FramesPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/FramesPageUnitTest.java
@@ -33,11 +33,9 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.WebDriverWait;
 import org.zaproxy.zap.extension.hud.tutorial.pages.AlertsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.FramesPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.UpgradePage;
-import org.zaproxy.zap.extension.hud.ui.Constants;
 import org.zaproxy.zap.extension.hud.ui.browser.BrowsersTest;
 import org.zaproxy.zap.extension.hud.ui.generic.GenericUnitTest;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
@@ -142,21 +140,19 @@ public class FramesPageUnitTest extends BrowsersTest {
         testDrawerTabsVisible(hud);
     }
 
-    private static void checkPanelVisible(WebDriver wd, WebElement panel) {
-        checkWithRetry(wd, driver -> panel.isDisplayed());
+    private static void checkPanelVisible(HUD hud, WebElement panel) {
+        checkWithRetry(hud, driver -> panel.isDisplayed());
         Assertions.assertEquals("block", panel.getCssValue("display"));
     }
 
-    private static void checkWithRetry(WebDriver driver, Function<WebDriver, Object> check) {
-        new WebDriverWait(driver, Constants.GENERIC_TESTS_TIMEOUT_SECS)
-                .until(wd -> check.apply(driver));
+    private static void checkWithRetry(HUD hud, Function<WebDriver, Object> check) {
+        hud.wbWait().until(wd -> check.apply(wd));
     }
 
     private static void testSidePanesVisible(HUD hud) {
-        WebDriver wd = hud.getWebDriver();
-        checkPanelVisible(wd, hud.waitForLeftPanel());
-        checkPanelVisible(wd, hud.waitForRightPanel());
-        checkPanelVisible(wd, hud.waitForBottomPanel());
+        checkPanelVisible(hud, hud.waitForLeftPanel());
+        checkPanelVisible(hud, hud.waitForRightPanel());
+        checkPanelVisible(hud, hud.waitForBottomPanel());
     }
 
     private static void testClickHudButton(WebDriver wd, boolean hidden) {
@@ -169,16 +165,15 @@ public class FramesPageUnitTest extends BrowsersTest {
         wd.switchTo().defaultContent();
     }
 
-    private static void checkPanelHidden(WebDriver wd, WebElement panel) {
-        checkWithRetry(wd, driver -> !panel.isDisplayed());
+    private static void checkPanelHidden(HUD hud, WebElement panel) {
+        checkWithRetry(hud, driver -> !panel.isDisplayed());
         Assertions.assertEquals("none", panel.getCssValue("display"));
     }
 
     private static void testSidePanesHidden(HUD hud) {
-        WebDriver wd = hud.getWebDriver();
-        checkPanelHidden(wd, hud.waitForLeftPanel());
-        checkPanelHidden(wd, hud.waitForRightPanel());
-        checkPanelVisible(wd, hud.waitForBottomPanel());
+        checkPanelHidden(hud, hud.waitForLeftPanel());
+        checkPanelHidden(hud, hud.waitForRightPanel());
+        checkPanelVisible(hud, hud.waitForBottomPanel());
     }
 
     private void testDrawerTabsVisible(HUD hud) {

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/PageAlertsPageUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/PageAlertsPageUnitTest.java
@@ -23,17 +23,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.zaproxy.zap.extension.hud.tutorial.pages.AlertNotificationsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.PageAlertsPage;
 import org.zaproxy.zap.extension.hud.tutorial.pages.SiteAlertsPage;
-import org.zaproxy.zap.extension.hud.ui.Constants;
 import org.zaproxy.zap.extension.hud.ui.browser.BrowsersTest;
 import org.zaproxy.zap.extension.hud.ui.generic.GenericUnitTest;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
@@ -76,35 +75,9 @@ public class PageAlertsPageUnitTest extends BrowsersTest {
 
         // Wait for the alert - this will depend on the ZAP passive scan thread
         WebElement panel = hud.waitForLeftPanel();
-
-        WebElement infoPageButton = null;
-        for (int i = 0; i < TutorialStatics.ALERT_LONG_LOOP_COUNT; i++) {
-            try {
-                assertNotNull(panel);
-                driver.switchTo().frame(panel);
-                List<WebElement> buttons = hud.getHudButtons();
-                if (buttons != null && buttons.size() >= 7) {
-                    infoPageButton = buttons.get(6);
-                    if (infoPageButton.getText().length() > 0
-                            && !infoPageButton.getText().equals("0")) {
-                        break;
-                    }
-                }
-                // Try again - the panel might have been reloaded
-                infoPageButton = null;
-                driver.switchTo().parentFrame();
-                panel = hud.waitForLeftPanel();
-            } catch (Exception e1) {
-                System.out.println("PageAlertsPage exception " + e1.getMessage());
-            }
-            try {
-                Thread.sleep(Constants.GENERIC_TESTS_RETRY_SLEEP_MS);
-            } catch (InterruptedException e) {
-                // Ignore
-            }
-        }
-        assertNotNull(infoPageButton);
-        assertEquals("1", infoPageButton.getText());
+        driver.switchTo().frame(panel);
+        WebElement infoPageButton = hud.getHudButtons().get(6);
+        hud.wbWait().until(ExpectedConditions.textToBePresentInElement(infoPageButton, "1"));
 
         // Click it, make sure we can see the alert
         infoPageButton.click();

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/TutorialStatics.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/browser/tutorial/TutorialStatics.java
@@ -36,8 +36,6 @@ public class TutorialStatics {
     public static By NEXT_BUTTON_BY_ID = By.id("next-button");
     public static By PREVIOUS_BUTTON_BY_ID = By.id("previous-button");
     public static int ALERT_LOOP_COUNT = 10;
-    // Long loop for alerts that can take some time to appear - hopefully can reduce in the future
-    public static int ALERT_LONG_LOOP_COUNT = 100;
 
     private static String getTutorialHostPort() {
         if (tutorialHostPort == null) {

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/generic/BottomPanelUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/generic/BottomPanelUnitTest.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.hud.ui.generic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -39,13 +38,13 @@ public class BottomPanelUnitTest {
     public static void testBottomPanelLoads(WebDriver wd) {
         HUD hud = new HUD(wd);
         Assertions.assertNotNull(hud.waitForBottomPanel());
+        wd.switchTo().defaultContent();
     }
 
     public static void testBottomContainsExpectedButtons(WebDriver wd) {
         HUD hud = new HUD(wd);
         List<WebElement> buttons = hud.waitForHudButtons(HUD.BOTTOM_PANEL_BY_ID, EXPECTED_BUTTONS);
-        assertNotNull(buttons);
         assertEquals(EXPECTED_BUTTONS, buttons.size());
-        wd.switchTo().parentFrame();
+        wd.switchTo().defaultContent();
     }
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/generic/LeftPanelUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/generic/LeftPanelUnitTest.java
@@ -19,12 +19,7 @@
  */
 package org.zaproxy.zap.extension.hud.ui.generic;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.List;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 public class LeftPanelUnitTest {
@@ -40,18 +35,13 @@ public class LeftPanelUnitTest {
 
     public static void testLeftPanelLoads(WebDriver wd) {
         HUD hud = new HUD(wd);
-        assertNotNull(hud.waitForLeftPanel());
+        hud.waitForLeftPanel();
+        wd.switchTo().defaultContent();
     }
 
     public static void testLeftContainsExpectedButtons(WebDriver wd) {
         HUD hud = new HUD(wd);
-        List<WebElement> buttons = hud.waitForHudButtons(HUD.LEFT_PANEL_BY_ID, EXPECTED_BUTTONS);
-        assertNotNull(buttons);
-        // An exact match would be better, but its proved to be too flaky :/
-        if (buttons.size() < EXPECTED_BUTTONS) {
-            hud.warning("LeftPanelUnitTest only found " + buttons.size() + " buttons");
-        }
-        assertTrue(buttons.size() >= EXPECTED_BUTTONS);
-        wd.switchTo().parentFrame();
+        hud.waitForHudButtons(HUD.LEFT_PANEL_BY_ID, EXPECTED_BUTTONS);
+        wd.switchTo().defaultContent();
     }
 }

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/generic/RightPanelUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/generic/RightPanelUnitTest.java
@@ -20,11 +20,8 @@
 package org.zaproxy.zap.extension.hud.ui.generic;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 import org.zaproxy.zap.extension.hud.ui.uimap.HUD;
 
 public class RightPanelUnitTest {
@@ -41,17 +38,12 @@ public class RightPanelUnitTest {
     public static void testRightPanelLoads(WebDriver wd) {
         HUD hud = new HUD(wd);
         assertNotNull(hud.waitForRightPanel());
+        wd.switchTo().defaultContent();
     }
 
     public static void testRightContainsExpectedButtons(WebDriver wd) {
         HUD hud = new HUD(wd);
-        List<WebElement> buttons = hud.waitForHudButtons(HUD.RIGHT_PANEL_BY_ID, EXPECTED_BUTTONS);
-        assertNotNull(buttons);
-        // An exact match would be better, but its proved to be too flaky :/
-        if (buttons.size() < EXPECTED_BUTTONS) {
-            hud.warning("RightPanelUnitTest only found " + buttons.size() + " buttons");
-        }
-        assertTrue(buttons.size() >= EXPECTED_BUTTONS);
-        wd.switchTo().parentFrame();
+        hud.waitForHudButtons(HUD.RIGHT_PANEL_BY_ID, EXPECTED_BUTTONS);
+        wd.switchTo().defaultContent();
     }
 }


### PR DESCRIPTION
Ensure the HUD is fully initialised before running the actual tests,
otherwise the HUD state might change while the checks are being done
leading to failures.
Ensure frame is restored after each test to have the expected state
in following tests.
Simplify button checks and assertions, with above changes it's no longer
necessary to try restore to the expected frame/state (it already is) and
the number of buttons is now implicitly asserted (either the required
number is found or it fails).
Update ChromeDriver to stable version.
Accept insecure certs when setting up the browsers (not enabled for
Chrome by default, do the same for Firefox for consistency).
Enable output of passed tests when running in Travis CI to not hit the
build timeout limit without output (happening when running the tests
with both browsers).

Part of #344 - Make functional tests more reliable