### PR TITLE
Scale the HUD button

### DIFF
--- a/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -57,6 +57,7 @@ import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.websocket.ExtensionWebSocket;
 import org.zaproxy.zap.utils.DesktopUtils;
+import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.OverlayIcon;
 import org.zaproxy.zap.view.ZapMenuItem;
 import org.zaproxy.zap.view.ZapToggleButton;
@@ -328,6 +329,7 @@ public class ExtensionHUD extends ExtensionAdaptor
             } else {
                 hudButton.setIcon(ICON);
             }
+            DisplayUtils.scaleIcon(hudButton);
         }
     }
 


### PR DESCRIPTION
Dont think this is worth mentioning in the changelog, but can if anyone disagrees :)

To test just change the display font size to something significantly different and restart ZAP.
Without this fix the HUD button is not correctly resized.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>