### PR TITLE
Fix Firefox 81 referer issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Problems with Firefox 81 due to referer header not being set cross domain. [#815](https://github.com/zaproxy/zap-hud/issues/815)
 
 ## [0.11.0] - 2020-08-06
 ### Added

--- a/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/HudAPI.java
@@ -40,12 +40,14 @@ import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteNode;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
@@ -436,10 +438,16 @@ public class HudAPI extends ApiImplementor {
             }
             // Inject content into specific files
             if (file.equals("target/inject.js")) {
+                // The referrer is on domain so should still work in Firefox
+                String referrer = msg.getRequestHeader().getHeader(HttpHeader.REFERER);
+                if (referrer != null) {
+                    url = StringEscapeUtils.escapeJavaScript(referrer);
+                }
                 String secret =
                         this.extension.getHudParam().isTutorialTestMode()
                                 ? SHARED_TEST_NON_SECRET
                                 : SHARED_SECRET;
+                logger.debug("Injecting url into inject.js: " + url);
                 contents =
                         contents.replace("<<URL>>", url).replace("<<ZAP_SHARED_SECRET>>", secret);
             }

--- a/src/main/zapHomeFiles/hud/display.js
+++ b/src/main/zapHomeFiles/hud/display.js
@@ -2,9 +2,10 @@
 let app;
 let tabId = '';
 let frameId = '';
+const urlParameter = utils.getParameter(document.location.href, 'url');
 const context = {
-	url: document.referrer,
-	domain: utils.parseDomainFromUrl(document.referrer)
+	url: urlParameter,
+	domain: utils.parseDomainFromUrl(urlParameter)
 };
 
 // Event dispatcher for Vue
@@ -1155,10 +1156,10 @@ navigator.serviceWorker.addEventListener('message', event => {
 
 /* The injected script makes the main frame visible */
 function showDisplayFrame() {
-	return utils.messageWindow(parent, {action: 'showMainDisplay'}, document.referrer);
+	return utils.messageWindow(parent, {action: 'showMainDisplay'}, context.url);
 }
 
 /* The injected script makes the main frame invisible */
 function hideDisplayFrame() {
-	parent.postMessage({action: 'hideMainDisplay'}, document.referrer);
+	parent.postMessage({action: 'hideMainDisplay'}, context.url);
 }

--- a/src/main/zapHomeFiles/hud/drawer.js
+++ b/src/main/zapHomeFiles/hud/drawer.js
@@ -3,9 +3,10 @@ let app;
 const eventBus = new Vue();
 let frameId = '';
 let tabId = '';
+const urlParameter = utils.getParameter(document.location.href, 'url');
 const context = {
-	url: document.referrer,
-	domain: utils.parseDomainFromUrl(document.referrer)
+	url: urlParameter,
+	domain: utils.parseDomainFromUrl(urlParameter)
 };
 
 Vue.component('history', {
@@ -239,14 +240,14 @@ Vue.component('tabs', {
 			this.isArrowUp = true;
 			localforage.setItem('drawer.isDrawerOpen', false)
 				.catch(utils.errorHandler);
-			parent.postMessage({tabId, frameId, action: 'hideBottomDrawer'}, document.referrer);
+			parent.postMessage({tabId, frameId, action: 'hideBottomDrawer'}, context.url);
 		},
 		openDrawer() {
 			this.isOpen = true;
 			this.isArrowUp = false;
 			localforage.setItem('drawer.isDrawerOpen', true)
 				.catch(utils.errorHandler);
-			parent.postMessage({tabId, frameId, action: 'showBottomDrawer'}, document.referrer);
+			parent.postMessage({tabId, frameId, action: 'showBottomDrawer'}, context.url);
 		},
 		toggleOpenClose() {
 			if (this.isOpen) {
@@ -420,7 +421,7 @@ Vue.component('drawer-button-showhide', {
 			localforage.setItem('settings.isHudVisible', true)
 				.then(function (value) {
 					this.icon = utils.getZapImagePath('radar.png');
-					parent.postMessage({tabId, frameId, action: 'showHudPanels'}, document.referrer);
+					parent.postMessage({tabId, frameId, action: 'showHudPanels'}, context.url);
 					eventBus.$emit('showTabs', {});
 				})
 				.catch(utils.errorHandler);
@@ -430,7 +431,7 @@ Vue.component('drawer-button-showhide', {
 			localforage.setItem('settings.isHudVisible', false)
 				.then(function (value) {
 					this.icon = utils.getZapImagePath('radar-grey.png');
-					parent.postMessage({tabId, frameId, action: 'hideHudPanels'}, document.referrer);
+					parent.postMessage({tabId, frameId, action: 'hideHudPanels'}, context.url);
 					eventBus.$emit('hideTabs', {});
 				})
 				.catch(utils.errorHandler);

--- a/src/main/zapHomeFiles/hud/growlerAlerts.js
+++ b/src/main/zapHomeFiles/hud/growlerAlerts.js
@@ -13,9 +13,10 @@ const alertQueue = [];
 
 let tabId = '';
 let frameId = '';
+const urlParameter = utils.getParameter(document.location.href, 'url');
 const context = {
-	url: document.referrer,
-	domain: utils.parseDomainFromUrl(document.referrer)
+	url: urlParameter,
+	domain: utils.parseDomainFromUrl(urlParameter)
 };
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -96,11 +97,11 @@ function showGrowlerAlert(alert) {
 }
 
 function expandFrame(lines) {
-	parent.postMessage({action: 'heightenGrowlerFrame', lines}, document.referrer);
+	parent.postMessage({action: 'heightenGrowlerFrame', lines}, context.url);
 }
 
 function shrinkFrame(lines) {
-	parent.postMessage({action: 'shortenGrowlerFrame', lines}, document.referrer);
+	parent.postMessage({action: 'shortenGrowlerFrame', lines}, context.url);
 }
 
 function getRiskFlag(risk) {

--- a/src/main/zapHomeFiles/hud/management.js
+++ b/src/main/zapHomeFiles/hud/management.js
@@ -16,9 +16,10 @@ const ZAP_SHARED_SECRET = '<<ZAP_SHARED_SECRET>>';
 let app;
 let tabId = '';
 let frameId = '';
+const urlParameter = utils.getParameter(document.location.href, 'url');
 const context = {
-	url: document.referrer,
-	domain: utils.parseDomainFromUrl(document.referrer)
+	url: urlParameter,
+	domain: utils.parseDomainFromUrl(urlParameter)
 };
 
 Vue.component('welcome-screen', {
@@ -38,7 +39,7 @@ Vue.component('welcome-screen', {
 			}
 
 			app.showWelcomeScreen = false;
-			parent.postMessage({action: 'contractManagement'}, document.referrer);
+			parent.postMessage({action: 'contractManagement'}, context.url);
 		}
 	},
 	data() {
@@ -70,13 +71,13 @@ document.addEventListener('DOMContentLoaded', () => {
 		// Temp time test
 		localforage.setItem('starttime', startTime);
 
-		parent.postMessage({action: 'hideAllDisplayFrames'}, document.referrer);
+		parent.postMessage({action: 'hideAllDisplayFrames'}, context.url);
 
 		localforage.setItem('is_first_load', true);
 
 		startServiceWorker();
 	} else {
-		parent.postMessage({action: 'showAllDisplayFrames'}, document.referrer);
+		parent.postMessage({action: 'showAllDisplayFrames'}, context.url);
 
 		// Temp time test
 		localforage.getItem('starttime')
@@ -92,7 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				localforage.setItem('is_first_load', false);
 
 				if (isFirstLoad && SHOW_WELCOME_SCREEN) {
-					parent.postMessage({action: 'expandManagement'}, document.referrer);
+					parent.postMessage({action: 'expandManagement'}, context.url);
 					app.showWelcomeScreen = true;
 				}
 			});
@@ -164,35 +165,35 @@ function serviceWorkerMessageListener(event) {
 
 	switch (message.action) {
 		case 'refreshTarget':
-			parent.postMessage({action: 'refresh'}, document.referrer);
+			parent.postMessage({action: 'refresh'}, context.url);
 			break;
 
 		case 'showEnable.on':
-			parent.postMessage({action: 'showEnable.on'}, document.referrer);
+			parent.postMessage({action: 'showEnable.on'}, context.url);
 			break;
 
 		case 'showEnable.off':
-			parent.postMessage({action: 'showEnable.off'}, document.referrer);
+			parent.postMessage({action: 'showEnable.off'}, context.url);
 			break;
 
 		case 'showEnable.count':
-			parent.postMessage({action: 'showEnable.count'}, document.referrer);
+			parent.postMessage({action: 'showEnable.count'}, context.url);
 			break;
 
 		case 'showComments.on':
-			parent.postMessage({action: 'showComments.on', suspicious: message.suspicious}, document.referrer);
+			parent.postMessage({action: 'showComments.on', suspicious: message.suspicious}, context.url);
 			break;
 
 		case 'showComments.off':
-			parent.postMessage({action: 'showComments.off'}, document.referrer);
+			parent.postMessage({action: 'showComments.off'}, context.url);
 			break;
 
 		case 'showComments.count':
-			parent.postMessage({action: 'showComments.count', suspicious: message.suspicious}, document.referrer);
+			parent.postMessage({action: 'showComments.count', suspicious: message.suspicious}, context.url);
 			break;
 
 		case 'commonAlerts.alert':
-			parent.postMessage(message, document.referrer);
+			parent.postMessage(message, context.url);
 			break;
 
 		case 'showTutorial':
@@ -219,7 +220,7 @@ function startServiceWorker() {
 			})
 			.then(() => {
 				// Refresh the frames so the service worker can take control
-				parent.postMessage({action: 'refreshAllFrames'}, document.referrer);
+				parent.postMessage({action: 'refreshAllFrames'}, context.url);
 			})
 			.catch(utils.errorHandler);
 	} else {

--- a/src/main/zapHomeFiles/hud/panel.js
+++ b/src/main/zapHomeFiles/hud/panel.js
@@ -9,9 +9,10 @@ let orientation = '';
 let panelKey = '';
 let frameId = '';
 let tabId = '';
+const urlParameter = utils.getParameter(document.location.href, 'url');
 const context = {
-	url: document.referrer,
-	domain: utils.parseDomainFromUrl(document.referrer)
+	url: urlParameter,
+	domain: utils.parseDomainFromUrl(urlParameter)
 };
 
 // The Vue app
@@ -142,7 +143,7 @@ Vue.component('hud-buttons', {
 		localforage.getItem('settings.isHudVisible')
 			.then(isHudVisible => {
 				if (isHudVisible !== null && !isHudVisible) {
-					return parent.postMessage({action: 'hideHudPanels'}, document.referrer);
+					return parent.postMessage({action: 'hideHudPanels'}, context.url);
 				}
 			})
 			.then(() => {
@@ -289,7 +290,7 @@ function expandPanel() {
 		action: 'expandPanel',
 		orientation
 	};
-	parent.postMessage(message, document.referrer);
+	parent.postMessage(message, context.url);
 }
 
 function contractPanel() {
@@ -298,5 +299,5 @@ function contractPanel() {
 		orientation
 	};
 
-	parent.postMessage(message, document.referrer);
+	parent.postMessage(message, context.url);
 }

--- a/src/main/zapHomeFiles/hud/target/inject.js
+++ b/src/main/zapHomeFiles/hud/target/inject.js
@@ -564,7 +564,7 @@ const injection = (function () {
 
 		const mframe = document.createElement('iframe');
 		mframe.id = MANAGEMENT;
-		mframe.src = ZAP_HUD_FILES + '/file/management.html?frameId=management&tabId=' + tabId;
+		mframe.src = ZAP_HUD_FILES + '/file/management.html?url=' + URL + '&frameId=management&tabId=' + tabId;
 		mframe.scrolling = 'no';
 		mframe.style = 'position: fixed; right: 0px; bottom: 50px; width:28px; height:60px; border: medium none; overflow: hidden; z-index: 2147483647;';
 
@@ -582,18 +582,18 @@ const injection = (function () {
 
 		const bframe = document.createElement('iframe');
 		bframe.id = BOTTOM_DRAWER;
-		bframe.src = ZAP_HUD_FILES + '/file/drawer.html?frameId=drawer&tabId=' + tabId;
+		bframe.src = ZAP_HUD_FILES + '/file/drawer.html?url=' + URL + '&frameId=drawer&tabId=' + tabId;
 		bframe.scrolling = 'no';
 		bframe.style = 'position: fixed; border: medium none; overflow: hidden; left: 0px; bottom: 0px; width: 100%; height: 50px; z-index: 2147483646;';
 
 		const dframe = document.createElement('iframe');
 		dframe.id = MAIN_DISPLAY;
-		dframe.src = ZAP_HUD_FILES + '/file/display.html?frameId=display&tabId=' + tabId;
+		dframe.src = ZAP_HUD_FILES + '/file/display.html?url=' + URL + '&frameId=display&tabId=' + tabId;
 		dframe.style = 'position: fixed; right: 0px; top: 0px; width: 100%; height: 100%; border: 0px none; display: none; z-index: 2147483647;';
 
 		const gframe = document.createElement('iframe');
 		gframe.id = GROWLER_ALERTS;
-		gframe.src = ZAP_HUD_FILES + '/file/growlerAlerts.html?frameId=growlerAlerts&tabId=' + tabId;
+		gframe.src = ZAP_HUD_FILES + '/file/growlerAlerts.html?url=' + URL + '&frameId=growlerAlerts&tabId=' + tabId;
 		gframe.style = 'position: fixed; right: 0px; bottom: 30px; width: 500px; height: 0px;border: 0px none; z-index: 2147483647;';
 
 		document.body.append(mframe);


### PR DESCRIPTION
Fixes #815

In most places I've just replaced the document.referrer with a URL parameter. We already use these so not a big change.
We do still use the referer header in one place but thats all on the target domain so still works on Firefox, and should keep working in the future.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>