### PR TITLE
Typo Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Fix typo in tutorial.
 
 ## [0.12.0] - 2020-10-15
 ### Fixed

--- a/src/main/zapHomeFiles/hudtutorial/en_GB/AlertNotifications.html
+++ b/src/main/zapHomeFiles/hudtutorial/en_GB/AlertNotifications.html
@@ -9,7 +9,7 @@
 	<h1>Alert Notifications</H1>
 	ZAP can raise alerts for a wide variety of potential security issues.
 	<p>
-	The first time that ZAP find a specific type of issue with a site it will show the name of the issue in a 
+	The first time that ZAP finds a specific type of issue with a site it will show the name of the issue in a 
 	notification that appears in the bottom right hand corner of your browser. 
 	<p>
 	Some alerts can apply to lots of pages on a site, so the HUD will only ever show you a notification the first


### PR DESCRIPTION
Just a grammar mistake ("ZAP find" should be "ZAP finds")