### PR TITLE
Accessibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix typo in tutorial.
-
+- Added initial accessibility fixes for modals and tabs
 ## [0.12.0] - 2020-10-15
 ### Fixed
 - Problems with Firefox 81 due to referer header not being set cross domain. [#815](https://github.com/zaproxy/zap-hud/issues/815)

--- a/src/main/zapHomeFiles/hud/display.html
+++ b/src/main/zapHomeFiles/hud/display.html
@@ -32,13 +32,13 @@
         <!-- a base modal component -->
         <template id="modal-template">
             <transition name="modal" @after-leave="afterLeave">
-            <div :class="{ 'active': true, 'modal': true, 'modal-wd': isWide, 'modal-sm': isSmall }" id="modal-id" v-show="show">
+            <div :class="{ 'active': true, 'modal': true, 'modal-wd': isWide, 'modal-sm': isSmall }" id="modal-id" v-show="show" role="dialog" aria-modal="true" aria-labelledby="modal-title">
                 <a href="#close" class="modal-overlay" aria-label="Close" @click="close"></a>
                 <div class="modal-container">
                     <div class="modal-header">
                         <slot name="header"></slot>
                         <a href="#close" class="btn btn-clear float-right" aria-label="Close" @click="close"></a>
-                        <div class="modal-title h5">{{title}}</div>
+                        <div class="modal-title h5" id="modal-title">{{title}}</div>
                     </div>
 
                     <div class="modal-body">
@@ -56,7 +56,7 @@
         <template id="nav-modal-template">
             <modal :title="title" :show="show" @close="close">
                 <div slot="header">
-                    <button v-if="isBackShowing" class="btn btn-action btn-sm float-left"  @click="back">
+                    <button v-if="isBackShowing" class="btn btn-action btn-sm float-left"  @click="back" aria-label=" Back">
                         <i class="icon icon-back"></i>
                     </button>
                 </div>
@@ -74,7 +74,7 @@
             <modal :title="title" :show="show" @close="close">
                 <div slot="body">
                     <div class="content">
-                        <span v-html="text">
+                        <span v-html="text"></span>
                     </div>
                 </div>
                 <div slot="footer">
@@ -254,7 +254,7 @@
             <modal :title="title" :show="show" @close="close">
                 <div slot="body">
                     <ul class="menu">
-                        <li v-for="(label, id) in items" class="menu-item" @click="itemSelect(id)"> {{ label }} </li>
+                        <li v-for="(label, id) in items" class="menu-item" @click="itemSelect(id)" role="link"> {{ label }} </li>
                     </ul>
                 </div>
             </modal>
@@ -265,7 +265,7 @@
             <modal :title="title" :show="show" @close="close">
                 <div slot="body">
                     <ul class="menu">
-                        <li v-for="(conf, id) in items" class="menu-item" @click="itemSelect(id)">
+                        <li v-for="(conf, id) in items" class="menu-item" @click="itemSelect(id)" role="link">
                             <img v-if="conf.startimage"  :src="'<<ZAP_HUD_FILES>>/image/' + conf.startimage" />
                             {{ conf.label }}
                             <img v-if="conf.endimage"  :src="'<<ZAP_HUD_FILES>>/image/' + conf.endimage" />
@@ -312,7 +312,7 @@
                 <div slot="footer">
                 	<div><span class="errorMessages">{{errors}}</span></div>
                 	<div class="float-left">
-                    <button :class="{'btn': true, 'disabled': isAscanDisabled}" @click="ascanRequest"> {{ $t('message.history_ascan_request') }} <img src="<<ZAP_HUD_FILES>>/image/flame.png" /> </button>
+                    <button :class="{'btn': true, 'disabled': isAscanDisabled}" @click="ascanRequest"> {{ $t('message.history_ascan_request') }} <img src="<<ZAP_HUD_FILES>>/image/flame.png" alt="Active Scan"/> </button>
                     </div>
                     <button class="btn btn-primary" @click="replay"> {{ $t('message.history_replay_console') }} </button>
                     <button class="btn" @click="replayInBrowser"> {{ $t('message.history_replay_browser') }} </button>
@@ -373,9 +373,9 @@
         <template id="tabs-template">
             <div>
                 <div class="tabs">
-                    <ul class="tab tab-block">
-                        <li v-for="tab in tabs" :class="{ 'active': tab.isActive, 'tab-item': true, 'disabled': tab.disabled }">
-                            <a :href="tab.href" @click="selectTab(tab)">{{ tab.name }}</a>
+                    <ul class="tab tab-block" role="tablist">
+                        <li v-for="tab in tabs" :class="{ 'active': tab.isActive, 'tab-item': true, 'disabled': tab.disabled }" role="presentation">
+                            <a :href="tab.href" @click="selectTab(tab)" :aria-selected="tab.isActive">{{ tab.name }} role="tab"></a>
                         </li>
                     </ul>
                 </div>

--- a/src/main/zapHomeFiles/hud/drawer.html
+++ b/src/main/zapHomeFiles/hud/drawer.html
@@ -13,7 +13,7 @@
 </head>
 <body>
     <div id="app">
-        <tabs>
+        <tabs role="tablist">
             <tab :name="$t('message.history_tool')" :id="'tab.history'">
                 <history></history>
             </tab>
@@ -126,9 +126,9 @@
     <template id="tabs-template">
         <div style="height: 100%;">
             <div class="tabs">
-                <ul class="tab">
-                    <li v-if="tabsVisible" v-for="tab in tabs" :class="{ 'active': tab.isActive, 'tab-item': true }">
-                        <a :id="tab.id" :href="tab.href" @click="selectTab(tab)" :class="{ 'badge': tab.isBadgeData}" :data-badge="tab.badgeData">{{ tab.name }}</a>
+                <ul class="tab" role="tablist"> 
+                    <li v-if="tabsVisible" v-for="tab in tabs" :class="{ 'active': tab.isActive, 'tab-item': true }" role="presentation">
+                        <a :id="tab.id" :href="tab.href" @click="selectTab(tab)" :class="{ 'badge': tab.isBadgeData}" :data-badge="tab.badgeData" :aria-selected=" tab.isActive">{{ tab.name }}</a>
                     </li>
                     <!-- invisible tab-item to push tab-action buttons right -->
                     <li v-if="tabsVisible" class="tab-item tab-action-spacer">


### PR DESCRIPTION
This PR adds some ARIA properties to the current UI, making it easier for screenreaders to infer what particular components are meant to be doing. In particular:

- Some unlabeled controls are now labeled
- - Modals will behave more like native modals where screenreaders are concerned, which also adds a quick way to navigate to them from the frames, as currently modals that open don't redirect screenreader focus
- tablists and tabs now have the appropriate semantic roles.

While ARIA is generally discouraged in favor of using semantic, native HTML, the current incarnation of the HUD would require quite the significant rewrite to make depending on semantic HTML viable.
While I am reasonably certain this won't break anything, I was unable to get the project to build to verify this. Probably a good idea to quickly pull down the branch to see if I didn't break any Vue magic unintentionally. ;)

