### PR TITLE
Change Dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
 


### PR DESCRIPTION
Per discussion, the add-on is not released that often that the
dependencies need to be updated everyday.