### PR TITLE
Automate more release steps

### DIFF
--- a/.github/workflows/prepare-release-add-on.yml
+++ b/.github/workflows/prepare-release-add-on.yml
@@ -1,15 +1,11 @@
-name: Release Add-On
+name: Prepare Release Add-on
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'gradle.properties'
+  workflow_dispatch:
 
 jobs:
-  release:
-    name: Build and Release Add-On
+  prepare-release:
+    name: Prepare Release
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -20,9 +16,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 8
-    - name: Generate Release State
-      run: ./gradlew generateReleaseStateLastCommit
-    - name: Build and Release Add-On
+    - name: Prepare Release and Create Pull Request
       env:
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
-      run: ./gradlew releaseAddOn
+      run: ./gradlew createPullRequestRelease

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,9 @@
+# Release
+
+The following steps should be followed to release the add-on:
+ 1. Run the workflow [Prepare Release Add-on](https://github.com/zaproxy/zap-hud/actions/workflows/prepare-release-add-on.yml),
+    to prepare the release. It creates a pull request updating the version and changelog;
+ 2. Merge the pull request.
+
+After merging the pull request the [Release Add-on](https://github.com/zaproxy/zap-hud/actions/workflows/release-add-on.yml) workflow
+will create the tag, create the release, trigger the update of the marketplace, and create a pull request preparing the next development iteration.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+version=0.13.0
+release=false


### PR DESCRIPTION
Add workflow to prepare the release.
Tweak existing workflow to do the release on merge.
Move version (and add release state) to a properties file to ease the
automation.
Update Gradle add-on plugin and build for the release automation.
Document steps to release the add-on.