### PR TITLE
Tidy up resource messages file

### DIFF
--- a/src/main/resources/org/zaproxy/zap/extension/hud/resources/Messages.properties
+++ b/src/main/resources/org/zaproxy/zap/extension/hud/resources/Messages.properties
@@ -1,5 +1,3 @@
-# This file defines the default (English) variants of all of the internationalised messages
-
 hud.api.action.log = Used by the HUD to log messages from the browser
 hud.api.action.recordRequest = Used by the HUD to cache a request the user wants to send in the browser
 hud.api.action.resetTutorialTasks = Reset the tutorial tasks so that they must be completed again
@@ -25,28 +23,28 @@ hud.cmdline.hudbrowser.help = Launches a browser as per the -hud option with the
 hud.cmdline.hudurl.help = Launches a browser as per the -hud option with the specified URL
 hud.cmdline.error.badbrowser = Invalid HUD browser specified, must be one of: {0}
 
-hud.desc						= Heads Up Display
-hud.script.type.hud				= HUD
-hud.toolbar.button.off.tooltip	= Enable the ZAP HUD
-hud.toolbar.button.on.tooltip	= Disable the ZAP HUD
+hud.desc = Heads Up Display
+hud.script.type.hud = HUD
+hud.toolbar.button.off.tooltip = Enable the ZAP HUD
+hud.toolbar.button.on.tooltip = Disable the ZAP HUD
 
 hud.menu.hudGroup = ZAP HUD Group
 
-hud.optionspanel.name	= HUD
-hud.optionspanel.button.baseDirectory	= Change
-hud.optionspanel.label.baseDirectory	= Base Directory:
+hud.optionspanel.name = HUD
+hud.optionspanel.button.baseDirectory = Change
+hud.optionspanel.label.baseDirectory = Base Directory:
 hud.optionspanel.label.enabledForDesktop = Enable when using the ZAP Desktop
 hud.optionspanel.label.enabledForDaemon = Enable when using ZAP in daemon mode
 hud.optionspanel.label.enableTelemetry = Enable anonymous telemetry
 hud.optionspanel.label.enableOnDomainMsgs = Enable on-domain messages
-hud.optionspanel.label.inScopeOnly		= Enable the HUD only for URLs that are in scope
+hud.optionspanel.label.inScopeOnly = Enable the HUD only for URLs that are in scope
 hud.optionspanel.label.showWelcomeScreen = Show the HUD welcome screen when a browser is opened
-hud.optionspanel.label.removeCsp		= Remove CSP from target pages
-hud.optionspanel.label.developmentMode	= Development mode
-hud.optionspanel.label.allowUnsafeEval	= <html>Allow unsafe-evals<br><font color='red'>Only use in a safe environment for compiling templates inline</font></html>
+hud.optionspanel.label.removeCsp = Remove CSP from target pages
+hud.optionspanel.label.developmentMode = Development mode
+hud.optionspanel.label.allowUnsafeEval = <html>Allow unsafe-evals<br><font color='red'>Only use in a safe environment for compiling templates inline</font></html>
 hud.optionspanel.label.resetTutorialTasks = Reset tutorial tasks
 hud.optionspanel.label.skipTutorialTasks = Skip tutorial tasks
-hud.optionspanel.warn.badBaseDir		= Base Directory either does not exist or is not readable
+hud.optionspanel.warn.badBaseDir = Base Directory either does not exist or is not readable
 
 hud.tutorial.button.index = Index
 hud.tutorial.button.next = Next:&nbsp;


### PR DESCRIPTION
Remove comment that says it's the default file as that gets copied to
the localized files.
Remove tabs after the keys.