### PR TITLE
Upload files to Crowdin on release and manually

### DIFF
--- a/.github/workflows/crowdin-upload-files.yml
+++ b/.github/workflows/crowdin-upload-files.yml
@@ -1,0 +1,19 @@
+name: Crowdin Upload Files
+
+on:
+  workflow_dispatch:
+
+jobs:
+  upload:
+    name: Upload Files
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Upload Files
+      env:
+        CROWDIN_AUTH_TOKEN: ${{ secrets.ZAPBOT_CROWDIN_TOKEN }}
+      run: ./gradlew crowdinUploadSourceFiles

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,3 +7,12 @@ The following steps should be followed to release the add-on:
 
 After merging the pull request the [Release Add-on](https://github.com/zaproxy/zap-hud/actions/workflows/release-add-on.yml) workflow
 will create the tag, create the release, trigger the update of the marketplace, and create a pull request preparing the next development iteration.
+
+## Localized Resources
+
+The resources that require localization (e.g. `Messages.properties`, help pages) are uploaded to the OWASP ZAP projects in
+[Crowdin](https://crowdin.com/) when the add-on is released, if required (for pre-translation) the resources can be uploaded manually at anytime
+by running the workflow [Crowdin Upload Files](https://github.com/zaproxy/zap-hud/actions/workflows/crowdin-upload-files.yml).
+
+The resulting localized resources are added/updated in the repository periodically (through a workflow in the
+[zap-admin repository](https://github.com/zaproxy/zap-admin/)).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,8 @@ import org.zaproxy.gradle.tasks.ZapStart
 plugins {
     `java-library`
     jacoco
-    id("org.zaproxy.add-on") version "0.6.0"
+    id("org.zaproxy.add-on") version "0.7.0"
+    id("org.zaproxy.crowdin") version "0.1.0"
     id("com.diffplug.spotless") version "5.12.1"
     id("org.ysb33r.nodejs.npm") version "0.10.0-alpha.1"
 }
@@ -81,6 +82,17 @@ zapAddOn {
                 }
             }
         }
+    }
+}
+
+crowdin {
+    credentials {
+        token.set(System.getenv("CROWDIN_AUTH_TOKEN"))
+    }
+
+    configuration {
+        file.set(file("gradle/crowdin.yml"))
+        tokens.set(mutableMapOf("%addOnId%" to zapAddOn.addOnId.get()))
     }
 }
 
@@ -361,5 +373,6 @@ val releaseAddOn by tasks.registering {
         dependsOn("createRelease")
         dependsOn("handleRelease")
         dependsOn("createPullRequestNextDevIter")
+        dependsOn("crowdinUploadSourceFiles")
     }
 }

--- a/gradle/crowdin.yml
+++ b/gradle/crowdin.yml
@@ -1,0 +1,46 @@
+projects:
+  - id: 9301
+    sources:
+      - dir: "src/main/resources/org/zaproxy/zap/extension/%addOnId%/resources"
+        crowdinPath:
+          dir: "/addons/%addOnId%"
+          filename: "%file_pathname%"
+        exportPattern:
+          dir: "/zaproxy/addons/%addOnId%"
+          filename: "%file_name%_%locale_with_underscore%%file_extension%"
+        includes:
+          - pattern: "Messages.properties"
+            type: "properties"
+
+  - id: 32705
+    sources:
+      - dir: "src/main/javahelp/org/zaproxy/zap/extension/%addOnId%/resources/help"
+        outputDir: "src/main/javahelp/org/zaproxy/zap/extension/%addOnId%/resources"
+        crowdinPath:
+          dir: "/addons/%addOnId%"
+          filename: "%file_pathname%"
+        exportPattern:
+          dir: "/zaproxy/addons/%addOnId%"
+          filename: "help_%locale_with_underscore%/%file_pathname%"
+        includes:
+          - pattern: "contents/***.html"
+          - pattern: "helpset.hs"
+            crowdinPathFilename: "%file_name%.xml"
+            exportPatternFilename: "help_%locale_with_underscore%/%file_name%_%locale_with_underscore%%file_extension%"
+            translatableElements:
+              - "/helpset/title"
+              - "/helpset/presentation/title"
+              - "/helpset/view/label"
+          - pattern: "toc.xml"
+            translatableElements:
+              # Crowdin doesn't support descendant axis
+              # "/toc/descendant::tocitem[@text]"
+              # Define manually some:
+              - "/toc/tocitem[@text]"
+              - "/toc/tocitem/tocitem[@text]"
+              - "/toc/tocitem/tocitem/tocitem[@text]"
+              - "/toc/tocitem/tocitem/tocitem/tocitem[@text]"
+              - "/toc/tocitem/tocitem/tocitem/tocitem/tocitem[@text]"
+          - pattern: "index.xml"
+            translatableElements:
+              - "/index/indexitem[@text]"


### PR DESCRIPTION
Change release process to upload the files to Crowdin as part of the
add-on release.
Add workflow to trigger the upload of the files, to allow to start to
translate the files before the actual release.