### PR TITLE
Use server provided by the Network add-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added semantic roles and better labelling for screen reader users.
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Depend on Network add-on for the tutorial server.
+
 ## [0.13.0] - 2021-10-06
 ### Changed
 - Update minimum ZAP version to 2.11.0.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,9 @@ zapAddOn {
 
         dependencies {
             addOns {
+                register("network") {
+                    version.set(">= 0.1.0")
+                }
                 register("websocket")
             }
         }
@@ -143,6 +146,7 @@ java {
 val jupiterVersion = "5.8.1"
 
 dependencies {
+    compileOnly("org.zaproxy.addon:network:0.1.0")
     compileOnly(files(fileTree("lib").files))
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")
@@ -152,6 +156,7 @@ dependencies {
     testImplementation("io.github.bonigarcia:selenium-jupiter:3.4.0")
     testImplementation("org.hamcrest:hamcrest-all:1.3")
     testImplementation("org.mockito:mockito-all:1.10.19")
+    testImplementation("org.zaproxy.addon:network:0.1.0")
     testImplementation(files(fileTree("lib").files))
 }
 

--- a/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -51,6 +51,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.extension.hud.tutorial.TutorialProxyServer;
@@ -115,6 +116,7 @@ public class ExtensionHUD extends ExtensionAdaptor
 
     static {
         List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
+        dependencies.add(ExtensionNetwork.class);
         dependencies.add(ExtensionScript.class);
         dependencies.add(ExtensionWebSocket.class);
 
@@ -190,7 +192,12 @@ public class ExtensionHUD extends ExtensionAdaptor
 
         this.getExtScript().addListener(this);
 
-        tutorialServer = new TutorialProxyServer(this);
+        tutorialServer =
+                new TutorialProxyServer(
+                        this,
+                        Control.getSingleton()
+                                .getExtensionLoader()
+                                .getExtension(ExtensionNetwork.class));
     }
 
     @Override
@@ -205,7 +212,7 @@ public class ExtensionHUD extends ExtensionAdaptor
 
         HudEventPublisher.unregister();
 
-        tutorialServer.stopServer();
+        tutorialServer.stop();
     }
 
     @Override


### PR DESCRIPTION
Replace the usage of core `ProxyServer` and related classes with the
`Server` provided by the add-on.

---
The build will fail, the add-on needs to be included in the weekly. The add-on also needs to be released to not require to push the binary to the repo.