### PR TITLE
Address warn with Java 18

### DIFF
--- a/src/main/java/org/zaproxy/zap/extension/hud/OptionsHudPanel.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/OptionsHudPanel.java
@@ -40,6 +40,7 @@ import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.view.LayoutHelper;
 
 /** The HUD options panel. */
+@SuppressWarnings("serial")
 public class OptionsHudPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = -1L;


### PR DESCRIPTION
Suppress the serialisation warning in UI class, not expected to be
serialised.
Update JaCoCo to latest version which fully supports Java 18.
Replace Gradle plugin to run npm which works correctly with newer Java
versions.

Part of zaproxy/zaproxy#7389.