### PR TITLE
Update geckodriver and reduce page load timeout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -366,7 +366,7 @@ tasks.withType<Test>().configureEach {
     systemProperties.putAll(
         mapOf(
             "wdm.chromeDriverVersion" to "83.0.4103.39",
-            "wdm.geckoDriverVersion" to "0.26.0",
+            "wdm.geckoDriverVersion" to "0.31.0",
             "wdm.forceCache" to "true"
         )
     )

--- a/src/test/java/org/zaproxy/zap/extension/hud/ui/uimap/HUD.java
+++ b/src/test/java/org/zaproxy/zap/extension/hud/ui/uimap/HUD.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
 import org.openqa.selenium.By;
@@ -51,6 +52,7 @@ public class HUD {
 
     public HUD(WebDriver webdriver) {
         this.webdriver = webdriver;
+        this.webdriver.manage().timeouts().pageLoadTimeout(30, TimeUnit.SECONDS);
     }
 
     public static String LEFT_PANEL_ID = "zap-hud-left-panel";


### PR DESCRIPTION
Update geckodriver to latest version.
Reduce the page load timeout from 300 to 30 seconds, to reduce the
overall time the tests take.