### PR TITLE
Remove `vue-template-compiler`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "lint-staged": "^12.4.1",
         "vue-loader": "^17.0.0",
         "vue-style-loader": "^4.1.3",
-        "vue-template-compiler": "^2.7.14",
         "webpack": "^5.72.0",
         "webpack-cli": "^4.10.0",
         "xo": "^0.37.1"
@@ -2991,12 +2990,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
-      "dev": true
-    },
     "node_modules/debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -5749,15 +5742,6 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "bin": {
-        "he": "bin/he"
       }
     },
     "node_modules/hmac-drbg": {
@@ -10952,16 +10936,6 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/vue-template-compiler": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
-      "dev": true,
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "lint-staged": "^12.4.1",
     "vue-loader": "^17.0.0",
     "vue-style-loader": "^4.1.3",
-    "vue-template-compiler": "^2.7.14",
     "webpack": "^5.72.0",
     "webpack-cli": "^4.10.0",
     "xo": "^0.37.1"


### PR DESCRIPTION
This commit upgrades the vue version to 2.7 which is the LTS version of 2.x series. This also removes the vue-template-compiler dependency as it is not required anymore. More: https://v2.vuejs.org/v2/guide/migration-vue-2-7.html#Vue-CLI-webpack

I have tested HUD after this upgrade and it seems to work fine.

Part of #1110