### PR TITLE
hud: Add main toolbar button stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Stats counter to the main toolbar button (Issue 8375).
 
 ## [0.19.0] - 2024-05-07
 ### Changed

--- a/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
+++ b/src/main/java/org/zaproxy/zap/extension/hud/ExtensionHUD.java
@@ -60,6 +60,7 @@ import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.websocket.ExtensionWebSocket;
 import org.zaproxy.zap.utils.DesktopUtils;
 import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.view.OverlayIcon;
 import org.zaproxy.zap.view.ZapMenuItem;
 import org.zaproxy.zap.view.ZapToggleButton;
@@ -368,6 +369,7 @@ public class ExtensionHUD extends ExtensionAdaptor
                         hudEnabledForDesktop = hudButton.isSelected();
                         getHudParam().setEnabledForDesktop(hudEnabledForDesktop);
                         setZapCanGetFocus(!hudEnabledForDesktop);
+                        Stats.incCounter("stats.ui.maintoolbar.button.hud");
                     });
         }
         return hudButton;


### PR DESCRIPTION
- Add stats counter to main toolbar button action.
- Add note to CHANGELOG.

Part of zaproxy/zaproxy#8375.